### PR TITLE
Add workflow_dispatch to "on" github action

### DIFF
--- a/.github/workflows/condarise.yaml
+++ b/.github/workflows/condarise.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
+
 jobs:
   build-publish:
     # Run on merge to main, where the commit name starts with "Bump version:" (for bumpversion)


### PR DESCRIPTION
For a _manual release_, for when I forget to prepend "Bump version:" on the PR title