### PR TITLE
Bump version: 2.2.0 → 2.3.0: Add hail.remote_tmpdir method

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.3.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -13,18 +13,16 @@ def init_query_service():
 
     billing_project = os.getenv('HAIL_BILLING_PROJECT')
     assert billing_project
-    hail_bucket = os.getenv('HAIL_BUCKET')
-    assert hail_bucket
     return asyncio.get_event_loop().run_until_complete(
         hl.init_service(
             default_reference='GRCh38',
             billing_project=billing_project,
-            remote_tmpdir=f'gs://{hail_bucket}/batch-tmp',
+            remote_tmpdir=remote_tmpdir(),
         )
     )
 
 
-def copy_common_env(job: hb.job.Job):
+def copy_common_env(job: hb.job.Job) -> None:
     """Copies common environment variables that we use to run Hail jobs.
 
     These variables are typically set up in the analysis-runner driver, but need to be
@@ -47,3 +45,13 @@ def copy_common_env(job: hb.job.Job):
         val = os.getenv(key)
         if val:
             job.env(key, val)
+
+
+def remote_tmpdir() -> str:
+    """Returns the remote_tmpdir to use for Hail initialization.
+
+    Requires the HAIL_BUCKET environment variable to be set."""
+
+    hail_bucket = os.getenv('HAIL_BUCKET')
+    assert hail_bucket
+    return f'gs://{hail_bucket}/batch-tmp'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='2.2.0',
+    version='2.3.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This will be useful for replacing the deprecated `bucket` parameter used in the analysis-runner.