### PR TITLE
Bump version: 2.3.0 → 2.4.0: Allow specifying a bucket for remote_tmpdir

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.4.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+from typing import Optional
 import hail as hl
 import hailtop.batch as hb
 
@@ -47,11 +48,12 @@ def copy_common_env(job: hb.job.Job) -> None:
             job.env(key, val)
 
 
-def remote_tmpdir() -> str:
+def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
     """Returns the remote_tmpdir to use for Hail initialization.
 
-    Requires the HAIL_BUCKET environment variable to be set."""
+    If `hail_bucket` is not specified explicitly, requires the HAIL_BUCKET environment variable to be set."""
 
-    hail_bucket = os.getenv('HAIL_BUCKET')
-    assert hail_bucket
+    if not hail_bucket:
+        hail_bucket = os.getenv('HAIL_BUCKET')
+        assert hail_bucket
     return f'gs://{hail_bucket}/batch-tmp'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='2.3.0',
+    version='2.4.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This is useful for when `HAIL_BUCKET` isn't set yet, e.g. in the `/server` of the analysis-runner.