### PR TITLE
Bump version: 2.4.0 → 2.5.0: Add hail.{dataset_path, output_path} functions

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.0
+current_version = 2.5.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -38,7 +38,7 @@ def copy_common_env(job: hb.job.Job) -> None:
         'CPG_DATASET_GCP_PROJECT',
         'CPG_DATASET_PATH',
         'CPG_DRIVER_IMAGE',
-        'CPG_OUTPUT',
+        'CPG_OUTPUT_SUFFIX',
         'HAIL_BILLING_PROJECT',
         'HAIL_BUCKET',
         'HAIL_JAR_URL',
@@ -64,8 +64,8 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
     """Returns a full path for the current dataset, given a category and path suffix.
 
     This is useful for specifying input files, as in contrast to the output_path
-    function, dataset_path does _not_ take the CPG_OUTPUT environment variable into
-    account.
+    function, dataset_path does _not_ take the CPG_OUTPUT_SUFFIX environment variable
+    into account.
 
     Examples
     --------
@@ -119,7 +119,7 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
 def output_path(suffix: str, category: Optional[str] = None) -> str:
     """Returns a full path for the given category and path suffix.
 
-    In contrast to the dataset_path function, output_path takes the CPG_OUTPUT
+    In contrast to the dataset_path function, output_path takes the CPG_OUTPUT_SUFFIX
     environment variable into account.
 
     Examples
@@ -135,7 +135,7 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
 
     Notes
     -----
-    Requires the `CPG_OUTPUT` environment variable to be set, in addition to the
+    Requires the `CPG_OUTPUT_SUFFIX` environment variable to be set, in addition to the
     requirements for `dataset_path`.
 
     Parameters
@@ -152,6 +152,6 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
     -------
     str
     """
-    output = os.getenv('CPG_OUTPUT')
+    output = os.getenv('CPG_OUTPUT_SUFFIX')
     assert output
     return dataset_path(os.path.join(output, suffix), category)

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -33,15 +33,16 @@ def copy_common_env(job: hb.job.Job) -> None:
     copied to the environment dictionary of the given Hail Batch job."""
 
     for key in (
-        'DRIVER_IMAGE',
-        'DATASET',
-        'ACCESS_LEVEL',
+        'CPG_ACCESS_LEVEL',
+        'CPG_DATASET',
+        'CPG_DATASET_GCP_PROJECT',
+        'CPG_DATASET_PATH',
+        'CPG_DRIVER_IMAGE',
+        'CPG_OUTPUT',
         'HAIL_BILLING_PROJECT',
         'HAIL_BUCKET',
         'HAIL_JAR_URL',
         'HAIL_SHA',
-        'DATASET_GCP_PROJECT',
-        'OUTPUT',
     ):
         val = os.getenv(key)
         if val:
@@ -57,3 +58,100 @@ def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
         hail_bucket = os.getenv('HAIL_BUCKET')
         assert hail_bucket
     return f'gs://{hail_bucket}/batch-tmp'
+
+
+def dataset_path(suffix: str, category: Optional[str] = None) -> str:
+    """Returns a full path for the current dataset, given a category and path suffix.
+
+    This is useful for specifying input files, as in contrast to the output_path
+    function, dataset_path does _not_ take the CPG_OUTPUT environment variable into
+    account.
+
+    Examples
+    --------
+    Assuming that the analysis-runner has been invoked with
+    `--dataset fewgenomes --access-level test --output 1kg_pca/v42`:
+
+    >>> from analysis_runner import bucket_path
+    >>> bucket_path('1kg_densified/combined.mt')
+    'gs://cpg-fewgenomes-test/1kg_densified/combined.mt'
+    >>> bucket_path('1kg_densified/report.html', 'web')
+    'gs://cpg-fewgenomes-test-web/1kg_densified/report.html'
+
+    Notes
+    -----
+    Requires either the
+    * `CPG_DATASET` and `CPG_ACCESS_LEVEL` environment variables, or the
+    * `CPG_DATASET_PATH` environment variable
+    to be set, where the former takes precedence.
+
+    Parameters
+    ----------
+    suffix : str
+        A path suffix to append to the bucket.
+    category : str, optional
+        A category like "upload", "tmp", "web". If omitted, defaults to the "main" and
+        "test" buckets based on the access level. See
+        https://github.com/populationgenomics/team-docs/tree/main/storage_policies
+        for a full list of categories and their use cases.
+
+    Returns
+    -------
+    str
+    """
+    dataset = os.getenv('CPG_DATASET')
+    access_level = os.getenv('CPG_ACCESS_LEVEL')
+
+    if dataset and access_level:
+        namespace = 'test' if access_level == 'test' else 'main'
+        if category is None:
+            category = namespace
+        elif category not in ('archive', 'upload'):
+            category = f'{namespace}-{category}'
+        prefix = f'cpg-{dataset}-{category}'
+    else:
+        prefix = os.getenv('CPG_DATASET_PATH') or ''  # coerce to str
+        assert prefix
+
+    return os.path.join('gs://', prefix, suffix)
+
+
+def output_path(suffix: str, category: Optional[str] = None) -> str:
+    """Returns a full path for the given category and path suffix.
+
+    In contrast to the dataset_path function, output_path takes the CPG_OUTPUT
+    environment variable into account.
+
+    Examples
+    --------
+    Assuming that the analysis-runner has been invoked with
+    `--dataset fewgenomes --access-level test --output 1kg_pca/v42`:
+
+    >>> from analysis_runner import output_path
+    >>> output_path('loadings.ht')
+    'gs://cpg-fewgenomes-test/1kg_pca/v42/loadings.ht'
+    >>> output_path('report.html', 'web')
+    'gs://cpg-fewgenomes-test-web/1kg_pca/v42/report.html'
+
+    Notes
+    -----
+    Requires the `CPG_OUTPUT` environment variable to be set, in addition to the
+    requirements for `dataset_path`.
+
+    Parameters
+    ----------
+    suffix : str
+        A path suffix to append to the bucket + output directory.
+    category : str, optional
+        A category like "upload", "tmp", "web". If omitted, defaults to the "main" and
+        "test" buckets based on the access level. See
+        https://github.com/populationgenomics/team-docs/tree/main/storage_policies
+        for a full list of categories and their use cases.
+
+    Returns
+    -------
+    str
+    """
+    output = os.getenv('CPG_OUTPUT')
+    assert output
+    return dataset_path(os.path.join(output, suffix), category)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='2.4.0',
+    version='2.5.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This will allow removing the corresponding functions from the `analysis-runner` library, which will enable writing more portable pipelines that don't depend on `analysis-runner`, but only `cpg-utils`.

This also introduces the use of a new environment variable: `CPG_DATASET_PATH`, which can be set in non-analysis-runner environments to specify a path without dataset / access-level.

Furthermore prefixes all the environment variables with `CPG_`, to avoid clashes.