### PR TITLE
Bump version: 2.5.1 → 3.0.0: init_service has been renamed to init_batch in Hail 0.2.93

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.1
+current_version = 3.0.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -7,7 +7,7 @@ import hail as hl
 import hailtop.batch as hb
 
 
-def init_query_service():
+def init_batch():
     """Initializes the Hail Query Service from within Hail Batch.
 
     Requires the HAIL_BILLING_PROJECT and HAIL_BUCKET environment variables to be set."""
@@ -15,7 +15,7 @@ def init_query_service():
     billing_project = os.getenv('HAIL_BILLING_PROJECT')
     assert billing_project
     return asyncio.get_event_loop().run_until_complete(
-        hl.init_service(
+        hl.init_batch(
             default_reference='GRCh38',
             billing_project=billing_project,
             remote_tmpdir=remote_tmpdir(),
@@ -41,8 +41,6 @@ def copy_common_env(job: hb.job.Job) -> None:
         'CPG_OUTPUT_PREFIX',
         'HAIL_BILLING_PROJECT',
         'HAIL_BUCKET',
-        'HAIL_JAR_URL',
-        'HAIL_SHA',
     ):
         val = os.getenv(key)
         if val:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='2.5.1',
+    version='3.0.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Also removes obsolete environment variables