### PR TITLE
Bump version: 3.0.0 → 3.1.0: Forward kwargs to init_batch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.1.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -7,7 +7,7 @@ import hail as hl
 import hailtop.batch as hb
 
 
-def init_batch():
+def init_batch(**kwargs):
     """Initializes the Hail Query Service from within Hail Batch.
 
     Requires the HAIL_BILLING_PROJECT and HAIL_BUCKET environment variables to be set."""
@@ -19,6 +19,7 @@ def init_batch():
             default_reference='GRCh38',
             billing_project=billing_project,
             remote_tmpdir=remote_tmpdir(),
+            **kwargs,
         )
     )
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -10,7 +10,13 @@ import hailtop.batch as hb
 def init_batch(**kwargs):
     """Initializes the Hail Query Service from within Hail Batch.
 
-    Requires the HAIL_BILLING_PROJECT and HAIL_BUCKET environment variables to be set."""
+    Requires the HAIL_BILLING_PROJECT and HAIL_BUCKET environment variables to be set.
+
+    Parameters
+    ----------
+    kwargs : keyword arguments
+        Forwarded directly to `hl.init_batch`.
+    """
 
     billing_project = os.getenv('HAIL_BILLING_PROJECT')
     assert billing_project

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='3.0.0',
+    version='3.1.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This is useful for parameters like `driver_cores` or `driver_memory`.