### PR TITLE
Bump version: 3.1.0 → 3.2.0: Add image_path function for specifying Docker image paths

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.1.0
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.2.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -45,6 +45,7 @@ def copy_common_env(job: hb.job.Job) -> None:
         'CPG_DATASET_GCP_PROJECT',
         'CPG_DATASET_PATH',
         'CPG_DRIVER_IMAGE',
+        'CPG_IMAGE_REGISTRY_PREFIX',
         'CPG_OUTPUT_PREFIX',
         'HAIL_BILLING_PROJECT',
         'HAIL_BUCKET',

--- a/cpg_utils/hail.py
+++ b/cpg_utils/hail.py
@@ -153,3 +153,29 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
     output = os.getenv('CPG_OUTPUT_PREFIX')
     assert output
     return dataset_path(os.path.join(output, suffix), category)
+
+
+def image_path(suffix: str) -> str:
+    """Returns a full path to a container image in the default registry.
+
+    Examples
+    --------
+    >>> image_path('bcftools:1.10.2')
+    'australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.10.2'
+
+    Notes
+    -----
+    Requires the `CPG_IMAGE_REGISTRY_PREFIX` environment variable to be set.
+
+    Parameters
+    ----------
+    suffix : str
+        Describes the location within the registry.
+
+    Returns
+    -------
+    str
+    """
+    prefix = os.getenv('CPG_IMAGE_REGISTRY_PREFIX')
+    assert prefix
+    return f'{prefix}/{suffix}'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='3.0.0',
+    version='3.1.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='3.1.0',
+    version='3.2.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Helps with making pipelines independent of the CPG environment.