### PR TITLE
Bump version: 3.3.1 → 3.3.2: Fix use of quote

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.1
+current_version = 3.3.2
 commit = True
 tag = False
 

--- a/cpg_utils/git.py
+++ b/cpg_utils/git.py
@@ -218,7 +218,9 @@ def prepare_git_job(
     # Note: for private GitHub repos we'd need to use a token to clone.
     # Any job commands here are evaluated in a bash shell, so user arguments should
     # be escaped to avoid command injection.
-    job.command(f'git clone --recurse-submodules https://github.com/{quote(organisation)}/{quote(repo_name)}.git')
+    job.command(
+        f'git clone --recurse-submodules https://github.com/{quote(organisation)}/{quote(repo_name)}.git'
+    )
     job.command(f'cd {quote(repo_name)}')
 
     # Except for the "test" access level, we check whether commits have been

--- a/cpg_utils/git.py
+++ b/cpg_utils/git.py
@@ -218,11 +218,7 @@ def prepare_git_job(
     # Note: for private GitHub repos we'd need to use a token to clone.
     # Any job commands here are evaluated in a bash shell, so user arguments should
     # be escaped to avoid command injection.
-    job.command(
-        quote(
-            f'git clone --recurse-submodules https://github.com/{organisation}/{repo_name}.git'
-        )
-    )
+    job.command(f'git clone --recurse-submodules https://github.com/{quote(organisation)}/{quote(repo_name)}.git')
     job.command(f'cd {quote(repo_name)}')
 
     # Except for the "test" access level, we check whether commits have been

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='3.3.1',
+    version='3.3.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fixes #27 

Reverts use of `quote` to the analysis-runner syntax. See issue for details