### PR TITLE
Add get_group_members for supporting GCS access-group cache

### DIFF
--- a/cpg_utils/permissions.py
+++ b/cpg_utils/permissions.py
@@ -28,7 +28,17 @@ def group_name_to_filename(
     return os.path.join(group_cache_location, base, version)
 
 
-def get_group_members(
+def get_group_members(group: str):
+    """Returns the members of the given group.
+
+    :param group: str The group to query.
+    :returns: List[str] Members of the group
+    """
+    # TODO: change this to call serverless function
+    return get_group_members_direct(group)
+
+
+def get_group_members_direct(
     group: str, group_cache_location=DEFAULT_GROUP_CACHE_LOCATION
 ) -> List[str]:
     """Returns the members of the given group.

--- a/cpg_utils/permissions.py
+++ b/cpg_utils/permissions.py
@@ -1,0 +1,40 @@
+"""Convenience functions related to permissions """
+from typing import List
+import os
+import re
+
+from cloudpathlib import AnyPath
+
+group_name_santise_matcher = re.compile(r'[^\w_-]+')
+
+DEFAULT_GROUP_CACHE_LOCATION = os.getenv(
+    'CPG_GROUP_CACHE_LOCATION', 'gs://cpg-group-cache'
+)
+
+
+def group_name_to_filename(
+    group_name: str,
+    version: str,
+    group_cache_location: str = DEFAULT_GROUP_CACHE_LOCATION,
+) -> str:
+    """
+    Convert google group name to GCS safe directory name.
+    Replace all non [alphanumeric characters and _-] with '_'.
+
+    >>> _group_name_to_filename('my-group_with+chars@populationgenomics.org.au')
+    'my-group_with_chars_populationgenomics_org_au'
+    """
+    base = group_name_santise_matcher.sub('_', group_name)
+    return os.path.join(group_cache_location, base, version)
+
+
+def get_group_members(
+    group: str, group_cache_location=DEFAULT_GROUP_CACHE_LOCATION
+) -> List[str]:
+    """Returns the members of the given group.
+
+    :param group: str The group to query.
+    :returns: List[str] Members of the group
+    """
+    filename = group_name_to_filename(group, 'latest', group_cache_location)
+    return AnyPath(filename).read_text().split(',')

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
     install_requires=[
         'google-auth',
         'google-cloud-secret-manager',
+        'cloudpathlib',
     ],
     include_package_data=True,
     keywords='bioinformatics',


### PR DESCRIPTION
- Supports https://github.com/populationgenomics/analysis-runner/pull/392
- Intentionally leaving out the `write`
- [ ] Replace get_group_members with access through serverless function