### PR TITLE
Bump version: 4.0.0 → 4.1.0

### DIFF
--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -12,6 +12,7 @@ import hailtop.batch as hb
 from cloudpathlib import CloudPath
 from cloudpathlib.anypath import to_anypath
 
+
 GCLOUD_AUTH_COMMAND = (
     'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
 )


### PR DESCRIPTION
Added a `bump2version:minor` in the previous commit, but didn't check that it was in the squash message 😢 

This commit is just to build the updated version without further changing the version