### PR TITLE
reference_path: strip leading slash in `suffix` to avoid Path.join ignoring prefix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.0
+current_version = 4.1.1
 commit = True
 tag = False
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -227,6 +227,7 @@ def reference_path(suffix: str) -> Union[CloudPath, Path]:
     """
     prefix = os.getenv('CPG_REFERENCE_PREFIX')
     assert prefix
+    suffix = suffix.strip('/')  # leading slash results in `prefix` entirely ignored
     return to_anypath(prefix) / suffix
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.1.0',
+    version='4.1.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Example that we want to avoid:
```
>>> reference_path('/my-file')
GSPath('gs://my-file')
```
vs
```
>>> reference_path('my-file')
GSPath('gs://cpg-reference/my-file')
```