### PR TITLE
Bump version: 4.1.3 → 4.2.0: Use a config file instead of environment variables

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.3
+current_version = 4.2.0
 commit = True
 tag = False
 

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -64,7 +64,7 @@ def get_config() -> MutableMapping[str, Any]:
     MutableMapping[str, Any]
     """
 
-    global _config_path, _config
+    global _config
     if _config is None:  # Lazily initialize the config.
         assert (
             _config_path

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -1,0 +1,62 @@
+"""Provides access to config variables."""
+
+import os
+from typing import Any, Dict, Optional, MutableMapping
+from cloudpathlib import AnyPath
+import toml
+
+_config_cache: Dict[str, MutableMapping[str, Any]] = dict()
+
+
+def get_config(config_path: Optional[str] = None) -> MutableMapping[str, Any]:
+    """Returns a configuration dictionary.
+
+    Examples
+    --------
+    Here's a typical configuration file in TOML format:
+
+    [hail]
+    billing_project = "tob-wgs"
+    bucket = "cpg-tob-wgs-hail"
+
+    [workflow]
+    access_level = "test"
+    dataset = "tob-wgs"
+    dataset_gcp_project = "tob-wgs"
+    driver_image = "australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:36c6d4548ef347f14fd34a5b58908057effcde82-hail-ad1fc0e2a30f67855aee84ae9adabc3f3135bd47"
+    image_registry_prefix = "australia-southeast1-docker.pkg.dev/cpg-common/images"
+    reference_prefix = "gs://cpg-reference"
+    output_prefix = "plasma/chr22/v6"
+
+    Notes
+    -----
+    Caches the result based on the config path alone.
+
+    Parameters
+    ----------
+    config_path: str, optional
+        A cloudpathlib-compatible path to a TOML file containing the configuration. If
+        this parameter not provided, the CPG_CONFIG_PATH environment variable is used
+        instead.
+
+    Returns
+    -------
+    dict
+    """
+
+    if config_path is None:
+        config_path = os.getenv('CPG_CONFIG_PATH')
+    assert config_path
+
+    cached = _config_cache.get(config_path)
+    if cached is not None:
+        return cached
+
+    with AnyPath(config_path).open() as f:
+        config_str = f.read()
+
+    # Print the config content, which is helpful for debugging.
+    print(f'Configuration at {config_path}:\n{config_str}')
+    config = _config_cache[config_path] = toml.loads(config_str)
+
+    return config

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -41,7 +41,7 @@ def get_config(config_path: Optional[str] = None) -> MutableMapping[str, Any]:
 
     Returns
     -------
-    dict
+    MutableMapping[str, Any]
     """
 
     if config_path is None:

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -36,8 +36,8 @@ def get_config(config_path: Optional[str] = None) -> MutableMapping[str, Any]:
     ----------
     config_path: str, optional
         A cloudpathlib-compatible path to a TOML file containing the configuration. If
-        this parameter not provided, the CPG_CONFIG_PATH environment variable is used
-        instead.
+        this parameter not provided, the CPG_CONFIG_PATH environment variable must be
+        set instead.
 
     Returns
     -------

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -19,8 +19,6 @@ GCLOUD_AUTH_COMMAND = (
     'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
 )
 
-_config = get_config()
-
 
 def init_batch(**kwargs):
     """
@@ -35,7 +33,7 @@ def init_batch(**kwargs):
     return asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
             default_reference='GRCh38',
-            billing_project=_config['hail']['billing_project'],
+            billing_project=get_config()['hail']['billing_project'],
             remote_tmpdir=remote_tmpdir(),
             **kwargs,
         )
@@ -64,7 +62,7 @@ def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
 
     If `hail_bucket` is not specified explicitly, requires the `hail/bucket` config variable to be set.
     """
-    return f'gs://{hail_bucket or _config["hail"]["bucket"]}/batch-tmp'
+    return f'gs://{hail_bucket or get_config()["hail"]["bucket"]}/batch-tmp'
 
 
 def dataset_path(suffix: str, category: Optional[str] = None) -> str:
@@ -107,8 +105,9 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
     -------
     str
     """
-    dataset = _config['workflow'].get('dataset')
-    access_level = _config['workflow'].get('access_level')
+    config = get_config()
+    dataset = config['workflow'].get('dataset')
+    access_level = config['workflow'].get('access_level')
 
     if dataset and access_level:
         namespace = 'test' if access_level == 'test' else 'main'
@@ -118,7 +117,7 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
             category = f'{namespace}-{category}'
         prefix = f'cpg-{dataset}-{category}'
     else:
-        prefix = _config['workflow']['dataset_path']
+        prefix = config['workflow']['dataset_path']
 
     return os.path.join('gs://', prefix, suffix)
 
@@ -162,7 +161,7 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
     str
     """
     return dataset_path(
-        os.path.join(_config['workflow']['output_prefix'], suffix), category
+        os.path.join(get_config()['workflow']['output_prefix'], suffix), category
     )
 
 
@@ -187,7 +186,7 @@ def image_path(suffix: str) -> str:
     -------
     str
     """
-    return f'{_config["workflow"]["image_registry_prefix"]}/{suffix}'
+    return f'{get_config()["workflow"]["image_registry_prefix"]}/{suffix}'
 
 
 def reference_path(suffix: str) -> Union[CloudPath, Path]:
@@ -212,7 +211,7 @@ def reference_path(suffix: str) -> Union[CloudPath, Path]:
     str
     """
     # A leading slash results in the prefix being ignored, therefore use strip below.
-    return to_anypath(_config['workflow']['reference_prefix']) / suffix.strip('/')
+    return to_anypath(get_config()['workflow']['reference_prefix']) / suffix.strip('/')
 
 
 def authenticate_cloud_credentials_in_job(

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -12,6 +12,8 @@ import hailtop.batch as hb
 from cloudpathlib import CloudPath
 from cloudpathlib.anypath import to_anypath
 
+from config import get_config
+
 
 GCLOUD_AUTH_COMMAND = (
     'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
@@ -21,20 +23,17 @@ GCLOUD_AUTH_COMMAND = (
 def init_batch(**kwargs):
     """
     Initializes the Hail Query Service from within Hail Batch.
-    Requires the HAIL_BILLING_PROJECT and HAIL_BUCKET environment variables to be set.
+    Requires the `hail/billing_project` and `hail/bucket` config variables to be set.
 
     Parameters
     ----------
     kwargs : keyword arguments
         Forwarded directly to `hl.init_batch`.
     """
-
-    billing_project = os.getenv('HAIL_BILLING_PROJECT')
-    assert billing_project
     return asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
             default_reference='GRCh38',
-            billing_project=billing_project,
+            billing_project=get_config()['hail']['billing_project'],
             remote_tmpdir=remote_tmpdir(),
             **kwargs,
         )
@@ -48,20 +47,11 @@ def copy_common_env(job: hb.batch.job.Job) -> None:
     passed through for "batch-in-batch" use cases.
 
     The environment variable values are extracted from the current process and
-    copied to the environment dictionary of the given Hail Batch job."""
-
-    for key in (
-        'CPG_ACCESS_LEVEL',
-        'CPG_DATASET',
-        'CPG_DATASET_GCP_PROJECT',
-        'CPG_DATASET_PATH',
-        'CPG_DRIVER_IMAGE',
-        'CPG_IMAGE_REGISTRY_PREFIX',
-        'CPG_REFERENCE_PREFIX',
-        'CPG_OUTPUT_PREFIX',
-        'HAIL_BILLING_PROJECT',
-        'HAIL_BUCKET',
-    ):
+    copied to the environment dictionary of the given Hail Batch job.
+    """
+    # If possible, please don't add new environment variables here, but instead add
+    # config variables.
+    for key in ('CPG_CONFIG_PATH',):
         val = os.getenv(key)
         if val:
             job.env(key, val)
@@ -70,12 +60,9 @@ def copy_common_env(job: hb.batch.job.Job) -> None:
 def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
     """Returns the remote_tmpdir to use for Hail initialization.
 
-    If `hail_bucket` is not specified explicitly, requires the HAIL_BUCKET environment variable to be set."""
-
-    if not hail_bucket:
-        hail_bucket = os.getenv('HAIL_BUCKET')
-        assert hail_bucket
-    return f'gs://{hail_bucket}/batch-tmp'
+    If `hail_bucket` is not specified explicitly, requires the `hail/bucket` config variable to be set.
+    """
+    return f'gs://{hail_bucket or get_config()["hail"]["bucket"]}/batch-tmp'
 
 
 def dataset_path(suffix: str, category: Optional[str] = None) -> str:
@@ -83,7 +70,7 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
     Returns a full path for the current dataset, given a category and path suffix.
 
     This is useful for specifying input files, as in contrast to the output_path
-    function, dataset_path does _not_ take the CPG_OUTPUT_PREFIX environment variable
+    function, dataset_path does _not_ take the `workflow/output_prefix` config variable
     into account.
 
     Examples
@@ -100,8 +87,8 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
     Notes
     -----
     Requires either the
-    * `CPG_DATASET` and `CPG_ACCESS_LEVEL` environment variables, or the
-    * `CPG_DATASET_PATH` environment variable
+    * `workflow/dataset` and `workflow/access_level` config variables, or the
+    * `workflow/dataset_path` config variable
     to be set, where the former takes precedence.
 
     Parameters
@@ -118,8 +105,8 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
     -------
     str
     """
-    dataset = os.getenv('CPG_DATASET')
-    access_level = os.getenv('CPG_ACCESS_LEVEL')
+    dataset = get_config()['workflow'].get('dataset')
+    access_level = get_config()['workflow'].get('access_level')
 
     if dataset and access_level:
         namespace = 'test' if access_level == 'test' else 'main'
@@ -129,8 +116,7 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
             category = f'{namespace}-{category}'
         prefix = f'cpg-{dataset}-{category}'
     else:
-        prefix = os.getenv('CPG_DATASET_PATH') or ''  # coerce to str
-        assert prefix
+        prefix = get_config()['workflow']['dataset_path']
 
     return os.path.join('gs://', prefix, suffix)
 
@@ -138,12 +124,12 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
 def output_path(suffix: str, category: Optional[str] = None) -> str:
     """Returns a full path for the given category and path suffix.
 
-    In contrast to the dataset_path function, output_path takes the CPG_OUTPUT_PREFIX
-    environment variable into account.
+    In contrast to the dataset_path function, output_path takes the `workflow/output_prefix`
+    config variable into account.
 
     Examples
     --------
-    If using the analysis-runner, the CPG_OUTPUT_PREFIX would be set to the argument
+    If using the analysis-runner, the `workflow/output_prefix` would be set to the argument
     provided using the --output argument, e.g.
     `--dataset fewgenomes --access-level test --output 1kg_pca/v42`:
     will use '1kg_pca/v42' as the base path to build upon in this method
@@ -156,7 +142,7 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
 
     Notes
     -----
-    Requires the `CPG_OUTPUT_PREFIX` environment variable to be set, in addition to the
+    Requires the `workflow/output_prefix` config variable to be set, in addition to the
     requirements for `dataset_path`.
 
     Parameters
@@ -173,9 +159,9 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
     -------
     str
     """
-    output = os.getenv('CPG_OUTPUT_PREFIX')
-    assert output
-    return dataset_path(os.path.join(output, suffix), category)
+    return dataset_path(
+        os.path.join(get_config()['workflow']['output_prefix'], suffix), category
+    )
 
 
 def image_path(suffix: str) -> str:
@@ -188,7 +174,7 @@ def image_path(suffix: str) -> str:
 
     Notes
     -----
-    Requires the `CPG_IMAGE_REGISTRY_PREFIX` environment variable to be set.
+    Requires the `workflow/image_registry_prefix` config variable to be set.
 
     Parameters
     ----------
@@ -199,9 +185,7 @@ def image_path(suffix: str) -> str:
     -------
     str
     """
-    prefix = os.getenv('CPG_IMAGE_REGISTRY_PREFIX')
-    assert prefix
-    return f'{prefix}/{suffix}'
+    return f'{get_config()["workflow"]["image_registry_prefix"]}/{suffix}'
 
 
 def reference_path(suffix: str) -> Union[CloudPath, Path]:
@@ -214,21 +198,19 @@ def reference_path(suffix: str) -> Union[CloudPath, Path]:
 
     Notes
     -----
-    Requires the `CPG_REFERENCE_PREFIX` environment variable to be set.
+    Requires the `workflow/reference_prefix` config variable to be set.
 
     Parameters
     ----------
     suffix : str
-        Describes path relative to CPG_REFERENCE_PREFIX.
+        Describes path relative to the reference prefix.
 
     Returns
     -------
     str
     """
-    prefix = os.getenv('CPG_REFERENCE_PREFIX')
-    assert prefix
-    suffix = suffix.strip('/')  # leading slash results in `prefix` entirely ignored
-    return to_anypath(prefix) / suffix
+    # A leading slash results in the prefix being ignored, therefore use strip below.
+    return to_anypath(get_config()['workflow']['reference_prefix']) / suffix.strip('/')
 
 
 def authenticate_cloud_credentials_in_job(

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -19,6 +19,8 @@ GCLOUD_AUTH_COMMAND = (
     'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
 )
 
+_config = get_config()
+
 
 def init_batch(**kwargs):
     """
@@ -33,7 +35,7 @@ def init_batch(**kwargs):
     return asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
             default_reference='GRCh38',
-            billing_project=get_config()['hail']['billing_project'],
+            billing_project=_config['hail']['billing_project'],
             remote_tmpdir=remote_tmpdir(),
             **kwargs,
         )
@@ -62,7 +64,7 @@ def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
 
     If `hail_bucket` is not specified explicitly, requires the `hail/bucket` config variable to be set.
     """
-    return f'gs://{hail_bucket or get_config()["hail"]["bucket"]}/batch-tmp'
+    return f'gs://{hail_bucket or _config["hail"]["bucket"]}/batch-tmp'
 
 
 def dataset_path(suffix: str, category: Optional[str] = None) -> str:
@@ -105,8 +107,8 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
     -------
     str
     """
-    dataset = get_config()['workflow'].get('dataset')
-    access_level = get_config()['workflow'].get('access_level')
+    dataset = _config['workflow'].get('dataset')
+    access_level = _config['workflow'].get('access_level')
 
     if dataset and access_level:
         namespace = 'test' if access_level == 'test' else 'main'
@@ -116,7 +118,7 @@ def dataset_path(suffix: str, category: Optional[str] = None) -> str:
             category = f'{namespace}-{category}'
         prefix = f'cpg-{dataset}-{category}'
     else:
-        prefix = get_config()['workflow']['dataset_path']
+        prefix = _config['workflow']['dataset_path']
 
     return os.path.join('gs://', prefix, suffix)
 
@@ -160,7 +162,7 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
     str
     """
     return dataset_path(
-        os.path.join(get_config()['workflow']['output_prefix'], suffix), category
+        os.path.join(_config['workflow']['output_prefix'], suffix), category
     )
 
 
@@ -185,7 +187,7 @@ def image_path(suffix: str) -> str:
     -------
     str
     """
-    return f'{get_config()["workflow"]["image_registry_prefix"]}/{suffix}'
+    return f'{_config["workflow"]["image_registry_prefix"]}/{suffix}'
 
 
 def reference_path(suffix: str) -> Union[CloudPath, Path]:
@@ -210,7 +212,7 @@ def reference_path(suffix: str) -> Union[CloudPath, Path]:
     str
     """
     # A leading slash results in the prefix being ignored, therefore use strip below.
-    return to_anypath(get_config()['workflow']['reference_prefix']) / suffix.strip('/')
+    return to_anypath(_config['workflow']['reference_prefix']) / suffix.strip('/')
 
 
 def authenticate_cloud_credentials_in_job(

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -62,7 +62,9 @@ def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
 
     If `hail_bucket` is not specified explicitly, requires the `hail/bucket` config variable to be set.
     """
-    return f'gs://{hail_bucket or get_config()["hail"]["bucket"]}/batch-tmp'
+    bucket = hail_bucket or get_config().get('hail', {}).get('bucket')
+    assert bucket, f'hail_bucket was not set by argument or configuration'
+    return f'gs://{bucket}/batch-tmp'
 
 
 def dataset_path(suffix: str, category: Optional[str] = None) -> str:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.1.3',
+    version='4.2.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The idea is to use a config file instead of more and more environment variables. This would depend on the analysis-runner uploading a config file as a blob before launching a batch, which is implemented in https://github.com/populationgenomics/analysis-runner/pull/410. We'd only need to set a single environment variable, `CPG_CONFIG_PATH`, to point to the blob.

At the moment, this simply passes through the dictionary returned by the TOML parser. We could instead have a config class with more clearly defined methods that map to the dictionary entries instead of allowing arbitrary strings. But I'm not sure that's adding much value apart from catching potential typos in the variable names when using strings. The current structure has the advantage that it nicely reflects the grouping mechanism in TOML (e.g. `hail` and `workflow` groups).