### PR TITLE
Parametrise path scheme in `dataset_path`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v4.2.0
   hooks:
   - id: check-yaml
     exclude: '\.*conda/.*'
@@ -15,17 +15,17 @@ repos:
   - id: check-added-large-files
 
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.22.0
+  rev: v0.31.1
   hooks:
   - id: markdownlint
 
 - repo: https://github.com/ambv/black
-  rev: 22.3.0
+  rev: '22.3.0'
   hooks:
   - id: black
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.8.4'
+  rev: '3.9.2'
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear, flake8-quotes]
@@ -41,6 +41,6 @@ repos:
 
 # Static type analysis (as much as it's possible in python using type hints)
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.812
+  rev: 'v0.950'
   hooks:
   - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v2.3.0
   hooks:
   - id: check-yaml
     exclude: '\.*conda/.*'
@@ -15,17 +15,17 @@ repos:
   - id: check-added-large-files
 
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.31.1
+  rev: v0.22.0
   hooks:
   - id: markdownlint
 
 - repo: https://github.com/ambv/black
-  rev: '22.3.0'
+  rev: 22.3.0
   hooks:
   - id: black
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.9.2'
+  rev: '3.8.4'
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear, flake8-quotes]
@@ -41,6 +41,6 @@ repos:
 
 # Static type analysis (as much as it's possible in python using type hints)
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.950'
+  rev: v0.812
   hooks:
   - id: mypy

--- a/cpg_utils/cloudpath_hail_az.py
+++ b/cpg_utils/cloudpath_hail_az.py
@@ -1,0 +1,107 @@
+"""
+Extend cloudpathlib Azure implementation to support hail-az:// scheme.
+Inspired by https://github.com/drivendataorg/cloudpathlib/issues/157
+"""
+
+import re
+from typing import Union, Optional
+from urllib.parse import urlparse
+
+from cloudpathlib import AzureBlobClient, AzureBlobPath
+from cloudpathlib.client import register_client_class
+from cloudpathlib.cloudpath import register_path_class, CloudPath
+from cloudpathlib.exceptions import InvalidPrefixError
+
+
+@register_client_class('hail-az')
+class HailAzureBlobClient(AzureBlobClient):
+    """
+    Client is identical to the base Azure implementation.
+    """
+
+
+@register_path_class('hail-az')
+class HailAzureBlobPath(AzureBlobPath):
+    """
+    Extending Path implementation to support hail-az:// and https:// schemes.
+    >>> CloudPath('hail-az://myaccount/mycontainer/tmp')
+    HailAzureBlobPath('hail-az://myaccount/mycontainer/tmp')
+    >>> CloudPath('https://myaccount.blob.core.windows.net/mycontainer/tmp')
+    HailAzureBlobPath('hail-az://myaccount/mycontainer/tmp')
+    """
+
+    cloud_prefix: str = 'hail-az://'
+    client: 'HailAzureBlobClient'
+
+    def __init__(
+        self,
+        cloud_path: Union[str, CloudPath],
+        client: Optional[AzureBlobClient] = None,
+        token: Optional[str] = None,
+    ):
+        if isinstance(cloud_path, str):
+            parsed = urlparse(cloud_path)
+            m = re.match(
+                r'(?P<account>[a-z0-9]+)(\.(?P<type>blob|dfs)(\.core\.windows\.net)?)?',
+                parsed.netloc,
+                flags=re.IGNORECASE,
+            )
+            if m is None:
+                raise ValueError(f"Bad Azure path '{cloud_path}'")
+            account = m.group('account')
+            fstype = m.group('type') or 'blob'
+            account_url = f'https://{account}.{fstype}.core.windows.net/'
+            optional_type = '' if fstype == 'blob' else '.' + fstype
+            cloud_path = (
+                f'{HailAzureBlobPath.cloud_prefix}{account}{optional_type}/'
+                f'{parsed.path.lstrip("/")}'
+            )
+            if (
+                client is None
+                or parsed.query
+                or token
+                or client.service_client.account_name != account
+            ):
+                if token is not None:
+                    token = '?' + token.lstrip('?')
+                elif parsed.query:
+                    token = '?' + parsed.query
+                client = HailAzureBlobClient(account_url, token)
+
+        super().__init__(cloud_path, client=client)
+
+    @classmethod
+    def is_valid_cloudpath(
+        cls, path: Union[str, CloudPath], raise_on_error=False
+    ) -> bool:
+        """
+        Also allowing HTTP.
+        """
+        valid = bool(
+            re.match(
+                fr'({HailAzureBlobPath.cloud_prefix}|https://[a-z0-9]+\.(blob|dfs)\.core\.windows\.net)',
+                str(path).lower(),
+            )
+        )
+
+        if raise_on_error and not valid:
+            raise InvalidPrefixError(
+                f'{path} is not a valid path since it does not start with {cls.cloud_prefix} '
+                f'or valid Azure https blob or dfs location.'
+            )
+
+        return valid
+
+    @property
+    def container(self) -> str:
+        """
+        Minus the account part.
+        """
+        return self._no_prefix.split('/', 2)[1]
+
+    @property
+    def blob(self) -> str:
+        """
+        No prefix, no account part.
+        """
+        return super().blob.split('/', 1)[1]

--- a/cpg_utils/cloudpath_hail_az.py
+++ b/cpg_utils/cloudpath_hail_az.py
@@ -47,7 +47,7 @@ class HailAzureBlobPath(AzureBlobPath):
                 flags=re.IGNORECASE,
             )
             if m is None:
-                raise ValueError(f"Bad Azure path '{cloud_path}'")
+                raise ValueError(f'Bad Azure path "{cloud_path}"')
             account = m.group('account')
             fstype = m.group('type') or 'blob'
             account_url = f'https://{account}.{fstype}.core.windows.net/'

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -80,7 +80,6 @@ def init_batch(**kwargs):
     kwargs : keyword arguments
         Forwarded directly to `hl.init_batch`.
     """
-
     return asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
             default_reference='GRCh38',

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -5,54 +5,18 @@ import inspect
 import os
 import pathlib
 import textwrap
+from enum import Enum
 from typing import Optional, Union, List
-from abc import ABC, abstractmethod
 
 import hail as hl
 import hailtop.batch as hb
 from cloudpathlib import CloudPath
 from cloudpathlib.anypath import to_anypath
 
-from cpg_utils.config import get_config
 
-
-# template commands strings
 GCLOUD_AUTH_COMMAND = (
     'gcloud -q auth activate-service-account --key-file=/gsa-key/key.json'
 )
-BASE_CMD = """
-import logging
-logger = logging.getLogger(__file__)
-logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
-logger.setLevel(logging.INFO)
-"""
-HAIL_STARTUP = """
-import asyncio
-import hail as hl
-asyncio.get_event_loop().run_until_complete(
-    hl.init_batch(
-        default_reference='{default_reference}',
-        billing_project='{hail_billing_project}',
-        remote_tmpdir='{hail_bucket}',
-    )
-)
-"""
-CMD_MODULE = """
-{source_module}
-{func_name}{func_args}
-"""
-CMD_SCRIPT = """
-set -o pipefail
-set -ex
-{gcloud_auth}
-
-{packages}
-
-cat << EOT >> script.py
-{command}
-EOT
-python3 script.py
-"""
 
 
 # Path can be either a cloud URL or a local posix file path.
@@ -65,7 +29,7 @@ to_path = to_anypath
 def init_batch(**kwargs):
     """
     Initializes the Hail Query Service from within Hail Batch.
-    Requires the `hail/billing_project` and `hail/bucket` config variables to be set.
+    Requires the HAIL_BILLING_PROJECT and HAIL_BUCKET environment variables to be set.
 
     Parameters
     ----------
@@ -73,12 +37,10 @@ def init_batch(**kwargs):
         Forwarded directly to `hl.init_batch`.
     """
 
-    billing_project = os.getenv('HAIL_BILLING_PROJECT')
-    assert billing_project
     return asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
             default_reference='GRCh38',
-            billing_project=get_config()['hail']['billing_project'],
+            billing_project=billing_project,
             remote_tmpdir=remote_tmpdir(),
             **kwargs,
         )
@@ -92,11 +54,21 @@ def copy_common_env(job: hb.batch.job.Job) -> None:
     passed through for "batch-in-batch" use cases.
 
     The environment variable values are extracted from the current process and
-    copied to the environment dictionary of the given Hail Batch job.
-    """
-    # If possible, please don't add new environment variables here, but instead add
-    # config variables.
-    for key in ('CPG_CONFIG_PATH',):
+    copied to the environment dictionary of the given Hail Batch job."""
+
+    for key in (
+        'CPG_ACCESS_LEVEL',
+        'CPG_DATASET',
+        'CPG_DATASET_GCP_PROJECT',
+        'CPG_DATASET_PATH',
+        'CPG_DRIVER_IMAGE',
+        'CPG_IMAGE_REGISTRY_PREFIX',
+        'CPG_REFERENCE_PREFIX',
+        'cpg_pipes/pipeline/cli_opts.py',
+        'CPG_OUTPUT_PREFIX',
+        'HAIL_BILLING_PROJECT',
+        'HAIL_BUCKET',
+    ):
         val = os.getenv(key)
         if val:
             job.env(key, val)
@@ -105,70 +77,21 @@ def copy_common_env(job: hb.batch.job.Job) -> None:
 def remote_tmpdir(hail_bucket: Optional[str] = None) -> str:
     """Returns the remote_tmpdir to use for Hail initialization.
 
-    If `hail_bucket` is not specified explicitly, requires the `hail/bucket` config variable to be set.
+    If `hail_bucket` is not specified explicitly, requires the HAIL_BUCKET environment variable to be set."""
+
+    if not hail_bucket:
+        hail_bucket = os.getenv('HAIL_BUCKET')
+        assert hail_bucket
+    return f'gs://{hail_bucket}/batch-tmp'
+
+
+class CloudPathProtocol(Enum):
     """
-    bucket = hail_bucket or get_config().get('hail', {}).get('bucket')
-    assert bucket, f'hail_bucket was not set by argument or configuration'
-    return f'gs://{bucket}/batch-tmp'
-
-
-class PathScheme(ABC):
-    """
-    Cloud storage path scheme. Constructs full paths to buckets and files.
-    """
-
-    @abstractmethod
-    def path_prefix(self, dataset: str, category: str) -> str:
-        """Build path prefix used in dataset_path"""
-
-    @abstractmethod
-    def full_path(self, prefix: str, suffix: str) -> str:
-        """Build full path from prefix and suffix"""
-
-    @staticmethod
-    def parse(val: str) -> 'PathScheme':
-        """Parse subclass name from string"""
-        if val == 'gs':
-            return GSPathScheme()
-        if val in ['az', 'hail-az']:
-            return AzurePathScheme()
-        raise ValueError(f'Unsupported path format: {val}. Available: gs, hail-az')
-
-
-class GSPathScheme(PathScheme):
-    """
-    Google Cloud Storage path scheme.
+    Cloud storage path protocol to parse and construct object URLs.
     """
 
-    def __init__(self):
-        self.scheme = 'gs'
-        self.prefix = 'cpg'
-
-    def path_prefix(self, dataset: str, category: str) -> str:
-        """Build path prefix used in dataset_path"""
-        return f'{self.prefix}-{dataset}-{category}'
-
-    def full_path(self, prefix: str, suffix: str) -> str:
-        """Build full path from prefix and suffix"""
-        return os.path.join(f'{self.scheme}://', prefix, suffix)
-
-
-class AzurePathScheme(PathScheme):
-    """
-    Azure Blob Storage path scheme, following the Hail Batch hail-az format.
-    """
-
-    def __init__(self, account: Optional[str] = 'cpg'):
-        self.scheme = 'hail-az'
-        self.account = os.getenv('CPG_AZURE_ACCOUNT', account)
-
-    def path_prefix(self, dataset: str, category: str) -> str:
-        """Build path prefix used in dataset_path"""
-        return f'{self.account}/{dataset}-{category}'
-
-    def full_path(self, prefix: str, suffix: str) -> str:
-        """Build full path from prefix and suffix"""
-        return os.path.join(f'{self.scheme}://', prefix, suffix)
+    GS = 'gs'
+    HAIL_AZ = 'hail-az'
 
 
 def dataset_path(
@@ -176,13 +99,13 @@ def dataset_path(
     category: Optional[str] = None,
     dataset: Optional[str] = None,
     access_level: Optional[str] = None,
-    path_scheme: Optional[str] = None,
+    cloud_path_protocol: Optional[CloudPathProtocol] = None,
 ) -> str:
     """
     Returns a full path for the current dataset, given a category and path suffix.
 
     This is useful for specifying input files, as in contrast to the output_path
-    function, dataset_path does _not_ take the `workflow/output_prefix` config variable
+    function, dataset_path does _not_ take the CPG_OUTPUT_PREFIX environment variable
     into account.
 
     Examples
@@ -195,14 +118,14 @@ def dataset_path(
     'gs://cpg-fewgenomes-test/1kg_densified/combined.mt'
     >>> dataset_path('1kg_densified/report.html', 'web')
     'gs://cpg-fewgenomes-test-web/1kg_densified/report.html'
-    >>> dataset_path('1kg_densified/report.html', path_scheme='hail-az')
+    >>> dataset_path('1kg_densified/report.html', cloud_path_protocol=CloudPathProtocol.HAIL_AZ)
     'hail-az://cpg/fewgenomes-test/1kg_densified/report.html'
 
     Notes
     -----
     Requires either the
-    * `workflow/dataset` and `workflow/access_level` config variables, or the
-    * `workflow/dataset_path` config variable
+    * `CPG_DATASET` and `CPG_ACCESS_LEVEL` environment variables, or the
+    * `CPG_DATASET_PATH` environment variable
     to be set, where the former takes precedence.
 
     Parameters
@@ -215,21 +138,22 @@ def dataset_path(
         https://github.com/populationgenomics/team-docs/tree/main/storage_policies
         for a full list of categories and their use cases.
     dataset : str, optional
-        Dataset name, takes precedence over the `workflow/dataset` config variable
+        Dataset name, takes precedence over the `CPG_DATASET` environment variable 
     access_level : str, optional
-        Access level, takes precedence over the `workflow/access_level` config variable
-    path_scheme: str, optional
-        Cloud storage path scheme, takes precedence over the `workflow/path_scheme`
-        config variable
+        Access level, takes precedence over the `CPG_ACCESS_LEVEL` environment variable 
+    cloud_path_protocol: str, optional
+        Cloud storage path protocol, takes precedence over `CPG_CLOUD_PATH_PROTOCOL`
 
     Returns
     -------
     str
     """
-    config = get_config()
-    dataset = dataset or config['workflow'].get('dataset')
-    access_level = access_level or config['workflow'].get('access_level')
-    path_scheme = path_scheme or config['workflow'].get('path_scheme', 'gs')
+    dataset = dataset or os.getenv('CPG_DATASET')
+    access_level = access_level or os.getenv('CPG_ACCESS_LEVEL')
+    cloud_path_protocol = cloud_path_protocol or os.getenv('CPG_CLOUD_PATH_PROTOCOL') or CloudPathProtocol.GS
+
+    cpg_prefix = 'cpg'
+    azure_account = os.getenv('CPG_AZURE_ACCOUNT', 'cpg')
 
     if dataset and access_level:
         namespace = 'test' if access_level == 'test' else 'main'
@@ -237,11 +161,24 @@ def dataset_path(
             category = namespace
         elif category not in ('archive', 'upload'):
             category = f'{namespace}-{category}'
-        prefix = PathScheme.parse(path_scheme).path_prefix(dataset, category)
-    else:
-        prefix = config['workflow']['dataset_path']
 
-    return PathScheme.parse(path_scheme).full_path(prefix, suffix)
+        if cloud_path_protocol == CloudPathProtocol.GS:
+            prefix = f'{cpg_prefix}-{dataset}-{category}'
+        elif cloud_path_protocol == CloudPathProtocol.HAIL_AZ:
+            prefix = f'{azure_account}/{dataset}-{category}'
+        else:
+            raise ValueError(f'Unsupported path protocol {cloud_path_protocol}')
+    else:
+        prefix = os.getenv('CPG_DATASET_PATH') or ''  # coerce to str
+        assert prefix
+
+    if cloud_path_protocol == CloudPathProtocol.GS:
+        return os.path.join('gs://', prefix, suffix)
+    elif cloud_path_protocol == CloudPathProtocol.HAIL_AZ:
+        return os.path.join('hail-az://', prefix, suffix)
+    else:
+        raise ValueError(f'Unsupported path protocol {cloud_path_protocol}')
+
 
 
 def web_url(
@@ -269,12 +206,12 @@ def web_url(
 def output_path(suffix: str, category: Optional[str] = None) -> str:
     """Returns a full path for the given category and path suffix.
 
-    In contrast to the dataset_path function, output_path takes the `workflow/output_prefix`
-    config variable into account.
+    In contrast to the dataset_path function, output_path takes the CPG_OUTPUT_PREFIX
+    environment variable into account.
 
     Examples
     --------
-    If using the analysis-runner, the `workflow/output_prefix` would be set to the argument
+    If using the analysis-runner, the CPG_OUTPUT_PREFIX would be set to the argument
     provided using the --output argument, e.g.
     `--dataset fewgenomes --access-level test --output 1kg_pca/v42`:
     will use '1kg_pca/v42' as the base path to build upon in this method
@@ -287,7 +224,7 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
 
     Notes
     -----
-    Requires the `workflow/output_prefix` config variable to be set, in addition to the
+    Requires the `CPG_OUTPUT_PREFIX` environment variable to be set, in addition to the
     requirements for `dataset_path`.
 
     Parameters
@@ -304,9 +241,9 @@ def output_path(suffix: str, category: Optional[str] = None) -> str:
     -------
     str
     """
-    return dataset_path(
-        os.path.join(get_config()['workflow']['output_prefix'], suffix), category
-    )
+    output = os.getenv('CPG_OUTPUT_PREFIX')
+    assert output
+    return dataset_path(os.path.join(output, suffix), category)
 
 
 def image_path(suffix: str) -> str:
@@ -319,7 +256,7 @@ def image_path(suffix: str) -> str:
 
     Notes
     -----
-    Requires the `workflow/image_registry_prefix` config variable to be set.
+    Requires the `CPG_IMAGE_REGISTRY_PREFIX` environment variable to be set.
 
     Parameters
     ----------
@@ -330,7 +267,9 @@ def image_path(suffix: str) -> str:
     -------
     str
     """
-    return os.path.join(get_config()['workflow']['image_registry_prefix'], suffix)
+    prefix = os.getenv('CPG_IMAGE_REGISTRY_PREFIX')
+    assert prefix
+    return os.path.join(prefix, suffix)
 
 
 def reference_path(suffix: str) -> Union[CloudPath, Path]:
@@ -343,19 +282,21 @@ def reference_path(suffix: str) -> Union[CloudPath, Path]:
 
     Notes
     -----
-    Requires the `workflow/reference_prefix` config variable to be set.
+    Requires the `CPG_REFERENCE_PREFIX` environment variable to be set.
 
     Parameters
     ----------
     suffix : str
-        Describes path relative to the reference prefix.
+        Describes path relative to CPG_REFERENCE_PREFIX.
 
     Returns
     -------
     str
     """
-    # A leading slash results in the prefix being ignored, therefore use strip below.
-    return to_anypath(get_config()['workflow']['reference_prefix']) / suffix.strip('/')
+    prefix = os.getenv('CPG_REFERENCE_PREFIX')
+    assert prefix
+    suffix = suffix.strip('/')  # leading slash results in `prefix` entirely ignored
+    return to_anypath(prefix) / suffix
 
 
 def authenticate_cloud_credentials_in_job(
@@ -403,22 +344,39 @@ def query_command(
     Constructs a command string to use with job.command().
     If hail_billing_project is provided, Hail Query will be initialised.
     """
-    python_cmd = BASE_CMD
+    python_cmd = f"""
+import logging
+logger = logging.getLogger(__file__)
+logging.basicConfig(format='%(levelname)s (%(name)s %(lineno)s): %(message)s')
+logger.setLevel(logging.INFO)
+"""
     if hail_billing_project:
         assert hail_bucket
-        python_cmd += HAIL_STARTUP.format(
-            default_reference=default_reference,
-            hail_billing_project=hail_billing_project,
-            hail_bucket=hail_bucket,
-        )
-    python_cmd += CMD_MODULE.format(
-        source_module=textwrap.dedent(inspect.getsource(module)),
-        func_name=func_name,
-        func_args=func_args,
+        python_cmd += f"""
+import asyncio
+import hail as hl
+asyncio.get_event_loop().run_until_complete(
+    hl.init_batch(
+        default_reference='{default_reference}',
+        billing_project='{hail_billing_project}',
+        remote_tmpdir='{hail_bucket}',
     )
+)
+"""
+    python_cmd += f"""
+{textwrap.dedent(inspect.getsource(module))}
+{func_name}{func_args}
+"""
+    cmd = f"""
+set -o pipefail
+set -ex
+{GCLOUD_AUTH_COMMAND if setup_gcp else ''}
 
-    return CMD_SCRIPT.format(
-        gcloud_auth=GCLOUD_AUTH_COMMAND if setup_gcp else '',
-        packages=('pip3 install ' + ' '.join(packages)) if packages else '',
-        python_cmd=python_cmd,
-    )
+{('pip3 install ' + ' '.join(packages)) if packages else ''}
+
+cat << EOT >> script.py
+{python_cmd}
+EOT
+python3 script.py
+"""
+    return cmd

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -133,11 +133,13 @@ class PathScheme(ABC):
     @staticmethod
     def parse(val: str) -> 'PathScheme':
         """Parse subclass name from string"""
-        if val == 'gs':
-            return GSPathScheme()
-        if val in ['az', 'hail-az']:
-            return AzurePathScheme()
-        raise ValueError(f'Unsupported path format: {val}. Available: gs, hail-az')
+        match val:
+            case 'gs':
+                return GSPathScheme()
+            case 'hail-az':
+                return AzurePathScheme()
+            case _:
+                raise ValueError(f'Unsupported path format: {val}. Available: gs, hail-az')
 
 
 class GSPathScheme(PathScheme):


### PR DESCRIPTION
Parametrise the cloud provider path scheme for `dataset_path`. For Azure, assuming the Hail's `hail-az` scheme.

Added: 
* `cloudpath_hail_az.py` module is an extension for `cloudpathlib` to support the `hail-az` scheme with `CloudPath`.
* Into `hail_bactch.py`: 
   * An abstract class for path protocol along with 2 implementations for `gs` and `hail-az` correspondingly.
   * Default path scheme is `gs`, and it can be parametrise in the config through `workflow/path_scheme`.
   * Explicitly parametrise `dataset_path()` with `dataset`, `access_level`, and `path_scheme`.
   * Add `Path` and `to_path` shortcuts are used everywhere in `cpg-pipes`, would be nice to have them in `cpg-utils` to aid moving code from one repository into another.