### PR TITLE
Bump version: 4.3.2 → 4.3.3: Validate config, include default toml into package

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.2
+current_version = 4.3.3
 commit = True
 tag = False
 

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -10,10 +10,20 @@ from frozendict import frozendict
 
 # We use these globals for lazy initialization, but pylint doesn't like that.
 # pylint: disable=global-statement, invalid-name
-_config_paths = (
-    _val.split(',') if (_val := os.getenv('CPG_CONFIG_PATH')) else []
-)  # See set_config_paths.
+_config_paths = _val.split(',') if (_val := os.getenv('CPG_CONFIG_PATH')) else []
 _config: Optional[frozendict] = None  # Cached config, initialized lazily.
+
+
+def _validate_configs(config_paths: list[str]) -> None:
+    if [p for p in config_paths if not p.endswith('.toml')]:
+        raise ValueError(
+            f'All config files must have ".toml" extensions, got: {config_paths}'
+        )
+    if bad_files := [p for p in config_paths if not AnyPath(p).exists()]:
+        raise ValueError(f'Some config files do not exist: {bad_files}')
+
+
+_validate_configs(_config_paths)
 
 
 def set_config_paths(config_paths: list[str]) -> None:
@@ -27,15 +37,9 @@ def set_config_paths(config_paths: list[str]) -> None:
     config_paths: list[str]
         A list of cloudpathlib-compatible paths to TOML files containing configurations.
     """
-
     global _config_paths, _config
     if _config_paths != config_paths:
-        if [p for p in config_paths if not p.endswith('.toml')]:
-            raise ValueError(
-                f'All config files must have .toml extensions, got: {config_paths}'
-            )
-        if bad_files := [p for p in config_paths if not AnyPath(p).exists()]:
-            raise ValueError(f'Some config files do not exist: {bad_files}')
+        _validate_configs(config_paths)
         _config_paths = config_paths
         os.environ['CPG_CONFIG_PATH'] = ','.join(_config_paths)
         _config = None  # Make sure the config gets reloaded.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.3.2',
+    version='4.3.3',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setuptools.setup(
         'toml',
         'frozendict',
     ],
-    include_package_data=True,
+    package_data={
+        'cpg_utils': ['config-template.toml'],
+    },
     keywords='bioinformatics',
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
1. When CPG_CONFIG_PATH is not set, `.split(',')` would return a list with one empty string `['']`, get_config() would still proceed trying to load a file `.`. Fixing this, and adding a validation function to catch issues.
2. Make sure the template is included in to the pip package.