### PR TITLE
 Bump version: 4.3.4 → 4.3.5: Add `fail_gracefully` flag to `read_secret`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.4
+current_version = 4.3.5
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.3.4',
+    version='4.3.5',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
* With the default `fail_gracefully=True`, current behaviour is kept, will only additionally print the exception.
* With `fail_gracefully=False`, will raise the exception.