### PR TITLE
upload pathing change

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.5
+current_version = 4.3.6
 commit = True
 tag = False
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -258,7 +258,7 @@ def dataset_path(
         namespace = Namespace.from_access_level(access_level)
         if category is None:
             category = namespace.value
-        elif category not in ('archive', 'upload'):
+        elif category != 'archive':
             category = f'{namespace.value}-{category}'
         prefix = PathScheme.parse(path_scheme).path_prefix(dataset, category)
     else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.3.5',
+    version='4.3.6',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I... think this is a correction?

When using dataset_path to create an upload path (i.e. cpg-validation-main-upload), this method currently creates `cpg-validation-upload` instead. 

Based on the [storage policy document](https://github.com/populationgenomics/team-docs/tree/main/storage_policies#upload-gscpg-dataset-maintest-upload), the `-upload` suffix should follow `test/main`, not replace it