### PR TITLE
Bump version: 4.3.6 → 4.4.0: Corrected format string

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.3.6
+current_version = 4.4.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -48,7 +48,7 @@ set -ex
 {packages}
 
 cat << EOT >> script.py
-{command}
+{python_cmd}
 EOT
 python3 script.py
 """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.3.6',
+    version='4.4.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
During an earlier formatting change I broke the format string. The `CMD_SCRIPT.format(` command tries to substitute the value python_cmd, but the string template has `command` :(