### PR TITLE
Config template updates

### DIFF
--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -30,9 +30,8 @@ access_level = 'standard'
 #last_stage =
 
 # Map of stages to lists of samples, to skip for specific stages
-# skip_samples_stages = {
-#   VerifyBamId = ['CPG13409']  # https://batch.hail.populationgenomics.org.au/batches/56236/jobs/372
-# }
+#[workflow.skip_samples_stages]
+#VerifyBamId = ['CPG13409']  # https://batch.hail.populationgenomics.org.au/batches/56236/jobs/372
 
 # Name of the pipeline (to prefix output paths)
 #name =
@@ -73,8 +72,11 @@ check_expected_outputs = true
 # If not provided, a temp folder will be created
 #local_tmp_dir =
 
-# Slack channel to send status reports with the CPG status reporter:
-#slack_channel = 'seqr-loader'
+# Slack channel to send status and QC reports:
+#[slack]
+#channel = 'seqr-loader-test'
+#token_secret_id = 'slack-seqr-loader-token'
+#token_project_id = 'seqr-308602'
 
 # When the sample-metadata database API returns an error from the
 # database, only show the error and continue, instead of crashing
@@ -100,7 +102,7 @@ sequencing_type = 'genome'
 # Realign CRAM when available, instead of using FASTQ.
 # The parameter value should correspond to CRAM version
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPG01234.cram
-realign_from_cram_version = 'bwamem'
+#realign_from_cram_version = 'bwamem'
 
 # Number of shards for realignment from BAM/CRAM
 realignment_shards_num = 10
@@ -120,24 +122,21 @@ use_gnarly = false
 # Use allele-specific annotations for VQSR
 use_as_vqsr = true
 
-# Run CRAM QC and PED checks
-cram_qc = true
-
 # Calling intervals (defauls to whole genome intervals)
 #intervals_path =
 
 # Create Seqr ElasticSearch indices for these datasets. If not specified, will
 # create indices for all input datasets.
-#create_es_index_for_datasets =
+#create_es_index_for_datasets = []
 
 [elasticsearch]
 # Configure access to ElasticSearch server
-es_port = 9243
-es_host = 'elasticsearch.es.australia-southeast1.gcp.elastic-cloud.com'
-es_username = 'seqr'
+port = 9243
+host = 'elasticsearch.es.australia-southeast1.gcp.elastic-cloud.com'
+username = 'seqr'
 # Load ElasticSearch password from a secret, unless SEQR_ES_PASSWORD is set
-es_password_secret_id = 'seqr-es-password'
-es_password_project_id = 'seqr-308602'
+password_secret_id = 'seqr-es-password'
+password_project_id = 'seqr-308602'
 
 [hail]
 #billing_project =
@@ -150,7 +149,6 @@ dry_run = false
 # Docker image URLs. Can be absolute or relative to `workflow.image_registry_prefix`.
 gatk = 'gatk:4.2.6.1'
 bcftools = 'bcftools:1.10.2--h4f4756c_2'
-sm-api = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:7d00c4871b2e96f50bae208e4184c3c4789a2fa4-hail-83056327f288917537531475ba475287b413db1c'
 bwa ='bwa:v0'
 bwamem2 = 'bwamem2:v0'
 dragmap = 'dragmap:1.3.0'
@@ -164,7 +162,8 @@ verify-bam-id = 'verify-bam-id:1.0.1'
 multiqc = 'multiqc:v1.12'
 fastqc = 'fastqc:v0.11.9_cv8'
 happy-vcfeval = 'happy-vcfeval:1.0'
-hail = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:7d00c4871b2e96f50bae208e4184c3c4789a2fa4-hail-83056327f288917537531475ba475287b413db1c'
+hail = 'driver:4225655198684124178417573ffc6ed714cf0c04-hail-d4bd6a2fd606634057b0277fce06cedce5b764a6'
+sm-api = 'driver:4225655198684124178417573ffc6ed714cf0c04-hail-d4bd6a2fd606634057b0277fce06cedce5b764a6'
 
 [references]
 # Genome build. Only GRCh38 is currently supported.
@@ -187,6 +186,8 @@ vep = 'vep/homo_sapiens_vep_105_GRCh38.tar'
 vep_mount = 'vep/GRCh38'
 # To cache intervals.
 intervals_prefix = 'intervals'
+# Liftover chain file to translate from GRCh38 to GRCh37 coordinates
+liftover_38_to_37 = 'liftover/grch38_to_grch37.over.chain.gz'
 
 ## The Broad references
 [references.broad]

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -1,7 +1,7 @@
 """Provides access to config variables."""
 
 import os
-from typing import Optional
+from typing import Optional, List, Dict
 
 import toml
 from cloudpathlib import AnyPath
@@ -14,7 +14,7 @@ _config_paths = _val.split(',') if (_val := os.getenv('CPG_CONFIG_PATH')) else [
 _config: Optional[frozendict] = None  # Cached config, initialized lazily.
 
 
-def _validate_configs(config_paths: list[str]) -> None:
+def _validate_configs(config_paths: List[str]) -> None:
     if [p for p in config_paths if not p.endswith('.toml')]:
         raise ValueError(
             f'All config files must have ".toml" extensions, got: {config_paths}'
@@ -26,7 +26,7 @@ def _validate_configs(config_paths: list[str]) -> None:
 _validate_configs(_config_paths)
 
 
-def set_config_paths(config_paths: list[str]) -> None:
+def set_config_paths(config_paths: List[str]) -> None:
     """Sets the config paths that are used by subsequent calls to get_config.
 
     If this isn't called, the value of the CPG_CONFIG_PATH environment variable is used
@@ -76,7 +76,7 @@ def get_config() -> frozendict:
     return _config
 
 
-def read_configs(config_paths: list[str]) -> frozendict:
+def read_configs(config_paths: List[str]) -> frozendict:
     """Creates a merged configuration from the given config paths.
 
     For a list of configurations (e.g. ['base.toml', 'override.toml']), the
@@ -120,7 +120,7 @@ def read_configs(config_paths: list[str]) -> frozendict:
     return frozendict(config)
 
 
-def update_dict(d1: dict, d2: dict) -> None:
+def update_dict(d1: Dict, d2: Dict) -> None:
     """Updates the d1 dict with the values from the d2 dict recursively in-place."""
     for k, v2 in d2.items():
         v1 = d1.get(k)

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 
 import hail as hl
 import hailtop.batch as hb
+from hail.utils.java import Env
 
 from cpg_utils.config import get_config
 from cpg_utils import to_path, Path
@@ -64,6 +65,9 @@ def init_batch(**kwargs):
     kwargs : keyword arguments
         Forwarded directly to `hl.init_batch`.
     """
+    # noinspection PyProtectedMember
+    if Env._hc:  # already initialised
+        return
     return asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
             default_reference=genome_build(),


### PR DESCRIPTION
Few fixes of config template:

* Fix `skip_samples_stages` option formatting
* `slack` section to use token secrets
* Comment out `realign_from_cram_version` in the template
* Fix `elasticsearch` section
* Use sm-api and driver images related to `cpg-common` (TODO to self: make sure we deploy them automatically`)
* Add `liftover_38_to_37` reference