### PR TITLE
Bump version: 4.5.1 → 4.5.2: Find all packages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.1
+current_version = 4.5.2
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.5.1',
+    version='4.5.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import setuptools
+from setuptools import find_packages, setup
 
-setuptools.setup(
+setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
     version='4.5.1',
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url=f'https://github.com/populationgenomics/cpg-utils',
     license='MIT',
-    packages=['cpg_utils'],
+    packages=find_packages(),
     install_requires=[
         'google-auth',
         'google-cloud-secret-manager',


### PR DESCRIPTION
Relevant to https://github.com/populationgenomics/production-pipelines/pull/81?

In my local IDE/python environment the cpg-utils.workflows module wasn't installed by pip for `cpg-utils==4.5.1`, only the scripts. Adding this produces a full installation of all the content within workflows, e.g.

`from cpg_utils.workflows.filetypes import AlignmentInput, FastqPairs, CramPath`