### PR TITLE
Bump version: 4.5.1 → 4.5.2: Fix packaging cpg_utils.workflows

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.1
+current_version = 4.5.2
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 setuptools.setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.5.1',
+    version='4.5.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url=f'https://github.com/populationgenomics/cpg-utils',
     license='MIT',
-    packages=['cpg_utils'],
+    packages=['cpg_utils']
+    + ['cpg_utils.' + p for p in sorted(setuptools.find_packages('./cpg_utils'))],
     install_requires=[
         'google-auth',
         'google-cloud-secret-manager',


### PR DESCRIPTION
Only top level files in a package are added into the wheel by default. Any lower-level modules should be specified explicitly in setup.py. In this PR, making sure `cpg_utils.workflows` is packaged.