### PR TITLE
VEP 104

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.2
+current_version = 4.5.3
 commit = True
 tag = False
 

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -91,18 +91,6 @@ web_url_template = 'https://{namespace}-web.populationgenomics.org.au/{dataset}'
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPG01234.cram
 #realign_from_cram_version = 'bwamem'
 
-# Number of shards for realignment from BAM/CRAM
-realignment_shards_num = 10
-
-# Number of intervals to partition sample genotyping
-hc_intervals_num = 50
-
-# Number of intervals to partition joint calling and VQSR
-jc_intervals_num = 50
-
-# Number of intervals to partition VEP annotation
-vep_intervals_num = 50
-
 # Use GnarlyGenotyper instead of GenotypeGVCFs
 use_gnarly = false
 
@@ -143,7 +131,7 @@ picard = 'picard_samtools:v0'
 picard_samtools = 'picard_samtools:v0'
 somalier = 'somalier:v0.2.15'
 peddy = 'peddy:v0'
-vep ='vep:105'
+vep ='vep:104.3'
 verifybamid = 'verifybamid:2.0.1'
 multiqc = 'multiqc:v1.12'
 fastqc = 'fastqc:v0.11.9_cv8'
@@ -165,11 +153,11 @@ somalier_1kg_targz = 'somalier/v0/1kg.somalier.tar.gz'
 # Somalier list of 1kg samples for the "ancestry" command.
 somalier_1kg_labels = 'somalier/v0/ancestry-labels-1kg.tsv'
 # LofTee reference tarball for VEP.
-vep_loftee = 'vep/loftee_GRCh38.tar'
+vep_loftee = 'vep/loftee.tar'
 # Reference tarball for VEP.
-vep = 'vep/homo_sapiens_vep_105_GRCh38.tar'
+vep_cache = 'vep/104.3/cache.tar'
 # Contains uncompressed VEP tarballs for mounting with cloudfuse.
-vep_mount = 'vep/GRCh38'
+vep_mount = 'vep/104.3/mount'
 # To cache intervals.
 intervals_prefix = 'intervals'
 # Liftover chain file to translate from GRCh38 to GRCh37 coordinates

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -91,18 +91,6 @@ web_url_template = 'https://{namespace}-web.populationgenomics.org.au/{dataset}'
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPG01234.cram
 #realign_from_cram_version = 'bwamem'
 
-# Number of shards for realignment from BAM/CRAM
-realignment_shards_num = 10
-
-# Number of intervals to partition sample genotyping
-hc_intervals_num = 50
-
-# Number of intervals to partition joint calling and VQSR
-jc_intervals_num = 50
-
-# Number of intervals to partition VEP annotation
-vep_intervals_num = 50
-
 # Use GnarlyGenotyper instead of GenotypeGVCFs
 use_gnarly = false
 

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -91,6 +91,18 @@ web_url_template = 'https://{namespace}-web.populationgenomics.org.au/{dataset}'
 # (e.g. v0 in gs://cpg-fewgenomes-main/cram/v0/CPG01234.cram
 #realign_from_cram_version = 'bwamem'
 
+# Number of shards for realignment from BAM/CRAM
+realignment_shards_num = 10
+
+# Number of intervals to partition sample genotyping
+hc_intervals_num = 50
+
+# Number of intervals to partition joint calling and VQSR
+jc_intervals_num = 50
+
+# Number of intervals to partition VEP annotation
+vep_intervals_num = 50
+
 # Use GnarlyGenotyper instead of GenotypeGVCFs
 use_gnarly = false
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.5.2',
+    version='4.5.3',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adjusting pointers in `images` and `references` to use VEP 104 by default.

FYI @MattWellie and @KatalinaBobowik it would break IAP and the VEP dataproc script in `ancestry`, but I'll follow up with corresponding PRs right after testing this change.

UPD: [context](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1661488085779609?thread_ts=1658208231.938539&cid=C018KFBCR1C). Happy to discuss if we want to support different versions for different domains. Or we could treat TOB as one-off, manually pin for one specific run, but use the latest and greatest in the default configs.