### PR TITLE
Use VEP 105 for RD

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.5.3
+current_version = 4.5.4
 commit = True
 tag = False
 

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -131,13 +131,13 @@ picard = 'picard_samtools:v0'
 picard_samtools = 'picard_samtools:v0'
 somalier = 'somalier:v0.2.15'
 peddy = 'peddy:v0'
-vep ='vep:104.3'
 verifybamid = 'verifybamid:2.0.1'
 multiqc = 'multiqc:v1.12'
 fastqc = 'fastqc:v0.11.9_cv8'
 happy = 'hap.py:v0.3.15'
 hail = 'driver:5d04b6d6bb411ea4b8750f40cf39fd0b701ea288-hail-c4eb2b16220d9872f417412ea565902f78739124'
 sm-api = 'driver:5d04b6d6bb411ea4b8750f40cf39fd0b701ea288-hail-c4eb2b16220d9872f417412ea565902f78739124'
+vep = 'vep:105.0'
 
 [references]
 # Genome build. Only GRCh38 is currently supported.
@@ -152,16 +152,13 @@ somalier_sites = 'somalier/v0/sites.hg38.vcf.gz'
 somalier_1kg_targz = 'somalier/v0/1kg.somalier.tar.gz'
 # Somalier list of 1kg samples for the "ancestry" command.
 somalier_1kg_labels = 'somalier/v0/ancestry-labels-1kg.tsv'
-# LofTee reference tarball for VEP.
-vep_loftee = 'vep/loftee.tar'
-# Reference tarball for VEP.
-vep_cache = 'vep/104.3/cache.tar'
-# Contains uncompressed VEP tarballs for mounting with cloudfuse.
-vep_mount = 'vep/104.3/mount'
 # To cache intervals.
 intervals_prefix = 'intervals'
 # Liftover chain file to translate from GRCh38 to GRCh37 coordinates
 liftover_38_to_37 = 'liftover/grch38_to_grch37.over.chain.gz'
+
+# Contains uncompressed VEP tarballs for mounting with cloudfuse.
+vep_mount = 'vep/105.0/mount'
 
 ## The Broad references
 [references.broad]

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -131,13 +131,13 @@ picard = 'picard_samtools:v0'
 picard_samtools = 'picard_samtools:v0'
 somalier = 'somalier:v0.2.15'
 peddy = 'peddy:v0'
+vep = 'vep:105.0'
 verifybamid = 'verifybamid:2.0.1'
 multiqc = 'multiqc:v1.12'
 fastqc = 'fastqc:v0.11.9_cv8'
 happy = 'hap.py:v0.3.15'
 hail = 'driver:5d04b6d6bb411ea4b8750f40cf39fd0b701ea288-hail-c4eb2b16220d9872f417412ea565902f78739124'
 sm-api = 'driver:5d04b6d6bb411ea4b8750f40cf39fd0b701ea288-hail-c4eb2b16220d9872f417412ea565902f78739124'
-vep = 'vep:105.0'
 
 [references]
 # Genome build. Only GRCh38 is currently supported.

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -152,13 +152,12 @@ somalier_sites = 'somalier/v0/sites.hg38.vcf.gz'
 somalier_1kg_targz = 'somalier/v0/1kg.somalier.tar.gz'
 # Somalier list of 1kg samples for the "ancestry" command.
 somalier_1kg_labels = 'somalier/v0/ancestry-labels-1kg.tsv'
+# Contains uncompressed VEP tarballs for mounting with cloudfuse.
+vep_mount = 'vep/105.0/mount'
 # To cache intervals.
 intervals_prefix = 'intervals'
 # Liftover chain file to translate from GRCh38 to GRCh37 coordinates
 liftover_38_to_37 = 'liftover/grch38_to_grch37.over.chain.gz'
-
-# Contains uncompressed VEP tarballs for mounting with cloudfuse.
-vep_mount = 'vep/105.0/mount'
 
 ## The Broad references
 [references.broad]

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -363,8 +363,8 @@ def reference_path(key: str) -> Path:
 
     Examples
     --------
-    >>> reference_path('vep/105.0/cache')
-    CloudPath('gs://cpg-reference/vep/105.0/cache.tar')
+    >>> reference_path('vep_mount')
+    CloudPath('gs://cpg-reference/vep/105.0/mount')
     >>> reference_path('broad/genome_calling_interval_lists')
     CloudPath('gs://cpg-reference/hg38/v0/wgs_calling_regions.hg38.interval_list')
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -363,8 +363,8 @@ def reference_path(key: str) -> Path:
 
     Examples
     --------
-    >>> reference_path('vep_loftee')
-    CloudPath('gs://cpg-reference/vep/loftee_GRCh38.tar')
+    >>> reference_path('vep/105.0/cache')
+    CloudPath('gs://cpg-reference/vep/105.0/cache.tar')
     >>> reference_path('broad/genome_calling_interval_lists')
     CloudPath('gs://cpg-reference/hg38/v0/wgs_calling_regions.hg38.interval_list')
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.5.3',
+    version='4.5.4',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
As a one-off for TOB in the populationgenomics domain, we use the `hl.vep()` driven by the dataproc backend to annotate, and there we can specifically pin to an earlier version. But for the batch-backend vep workfllow that is used for the RD domain, can keep the default to 105.