### PR TITLE
Workflow: separate CramPath and BamPath classes, with explicit index_path

### DIFF
--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -186,7 +186,6 @@ exome_calling_interval_lists = 'exome_calling_regions.v1.interval_list'
 genome_evaluation_interval_lists = 'wgs_evaluation_regions.hg38.interval_list'
 exome_evaluation_interval_lists = 'exome_evaluation_regions.v1.interval_list'
 genome_coverage_interval_list = 'wgs_coverage_regions.hg38.interval_list'
-unpadded_intervals = 'hg38.even.handcurated.20k.intervals'
 
 # VQSR (relative to broad_ref)
 dbsnp_vcf = 'Homo_sapiens_assembly38.dbsnp138.vcf'

--- a/cpg_utils/workflows/batch.py
+++ b/cpg_utils/workflows/batch.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 import hailtop.batch as hb
 import toml
-from cloudpathlib import CloudPath
 from cpg_utils import to_path
 from cpg_utils import config
 from cpg_utils.config import get_config

--- a/cpg_utils/workflows/batch.py
+++ b/cpg_utils/workflows/batch.py
@@ -5,9 +5,11 @@ Extending the Hail's `Batch` class.
 import os
 import tempfile
 import logging
+import uuid
 from typing import Optional
 
 import hailtop.batch as hb
+import toml
 from cloudpathlib import CloudPath
 from cpg_utils import to_path
 from cpg_utils import config
@@ -65,19 +67,10 @@ class Batch(hb.Batch):
         if isinstance(self._backend, hb.LocalBackend):
             return
         remote_dir = to_path(self._backend.remote_tmpdir) / 'config'
-        remote_paths = []
-        # noinspection PyProtectedMember
-        for path in config._config_paths:
-            path = to_path(path)
-            if isinstance(path, CloudPath):
-                remote_paths.append(str(path))
-            else:
-                remote_path = remote_dir / path.name
-                with path.open() as inp, remote_path.open('w') as out:
-                    out.write(inp.read())
-                remote_paths.append(str(remote_path))
-        config.set_config_paths(remote_paths)
-        os.environ['CPG_CONFIG_PATH'] = ','.join(remote_paths)
+        config_path = remote_dir / (str(uuid.uuid4()) + '.toml')
+        with config_path.open('w') as f:
+            toml.dump(dict(get_config()), f)
+        config.set_config_paths([str(config_path)])
 
     def _process_attributes(
         self,

--- a/cpg_utils/workflows/filetypes.py
+++ b/cpg_utils/workflows/filetypes.py
@@ -117,9 +117,9 @@ class CramPath(CramOrBamPath):
         self,
         path: str | Path,
         index_path: str | Path | None = None,
-        reference_assembly: str = None,
+        reference_assembly: str | Path = None,
     ):
-        self.reference_assembly = reference_assembly
+        self.reference_assembly = to_path(reference_assembly)
         super().__init__(path, index_path)
         self.somalier_path = to_path(f'{self.path}.somalier')
 

--- a/cpg_utils/workflows/filetypes.py
+++ b/cpg_utils/workflows/filetypes.py
@@ -58,15 +58,12 @@ class CramOrBamPath(AlignmentInput, ABC):
     def __str__(self) -> str:
         """
         >>> str(CramPath('gs://bucket/sample.cram', 'gs://bucket/sample.cram.crai'))
-        'CRAM(gs://bucket/sample{.cram,.cram.crai})'
+        'CRAM(gs://bucket/sample.cram+.cram.crai)'
         """
         res = str(self.path)
         if self.index_path:
             assert self.full_index_suffix
-            res = (
-                str(self.path.with_suffix(''))
-                + f'{{{self.path.suffix},{self.full_index_suffix}}}'
-            )
+            res += f'+{self.full_index_suffix}'
         return f'{self.ext.upper()}({res})'
 
     def exists(self) -> bool:

--- a/cpg_utils/workflows/filetypes.py
+++ b/cpg_utils/workflows/filetypes.py
@@ -41,7 +41,9 @@ class CramOrBamPath(AlignmentInput, ABC):
         if index_path:
             self.index_path = to_path(index_path)
             assert self.index_path.suffix == f'.{self.index_ext}'
-            self.full_index_suffix = str(self.index_path).replace(self.path.stem, '')
+            self.full_index_suffix = str(self.index_path).replace(
+                str(self.path.with_suffix('')), ''
+            )
 
     @property
     @abstractmethod
@@ -54,13 +56,18 @@ class CramOrBamPath(AlignmentInput, ABC):
         ...
 
     def __str__(self) -> str:
-        repr = str(self.path)
+        """
+        >>> str(CramPath('gs://bucket/sample.cram', 'gs://bucket/sample.cram.crai'))
+        'CRAM(gs://bucket/sample{.cram,.cram.crai})'
+        """
+        res = str(self.path)
         if self.index_path:
             assert self.full_index_suffix
-            repr = (
-                str(self.path.stem) + f'{{{self.path.suffix},{self.full_index_suffix}}}'
+            res = (
+                str(self.path.with_suffix(''))
+                + f'{{{self.path.suffix},{self.full_index_suffix}}}'
             )
-        return f'{self.ext.upper()}({repr})'
+        return f'{self.ext.upper()}({res})'
 
     def exists(self) -> bool:
         """
@@ -119,7 +126,9 @@ class CramPath(CramOrBamPath):
         index_path: str | Path | None = None,
         reference_assembly: str | Path = None,
     ):
-        self.reference_assembly = to_path(reference_assembly)
+        self.reference_assembly = None
+        if reference_assembly:
+            self.reference_assembly = to_path(reference_assembly)
         super().__init__(path, index_path)
         self.somalier_path = to_path(f'{self.path}.somalier')
 

--- a/cpg_utils/workflows/filetypes.py
+++ b/cpg_utils/workflows/filetypes.py
@@ -223,14 +223,14 @@ class FastqPairs(list[FastqPair], AlignmentInput):
         """
         Glob string to find all FASTQ files.
 
-        >>> FastqPairs([
+        >>> str(FastqPairs([
         >>>     FastqPair('gs://sample_R1.fq.gz', 'gs://sample_R2.fq.gz'),
-        >>> ]).path_glob()
+        >>> ]))
         'gs://sample_R{2,1}.fq.gz'
-        >>> FastqPairs([
+        >>> str(FastqPairs([
         >>>     FastqPair('gs://sample_L1_R1.fq.gz', 'gs://sample_L1_R2.fq.gz'),
         >>>     FastqPair('gs://sample_L2_R1.fq.gz', 'gs://sample_L2_R2.fq.gz'),
-        >>> ]).path_glob()
+        >>> ]))
         'gs://sample_L{2,1}_R{2,1}.fq.gz'
         """
         all_fastq_paths = []

--- a/cpg_utils/workflows/inputs.py
+++ b/cpg_utils/workflows/inputs.py
@@ -192,12 +192,12 @@ def _populate_analysis(cohort: Cohort) -> None:
             dataset=dataset.name,
         )
         for sample in dataset.get_samples():
-            if an := gvcf_by_sid.get(sample.id):
-                if an.output:
-                    sample.gvcf = GvcfPath(an.output)
-            if an := cram_by_sid.get(sample.id):
-                if an.output:
-                    sample.cram = CramPath(an.output)
+            if analysis := gvcf_by_sid.get(sample.id):
+                if analysis.output:
+                    assert analysis.output == sample.make_gvcf_path().path, analysis.output
+            if analysis := cram_by_sid.get(sample.id):
+                if analysis.output:
+                    assert analysis.output == sample.make_cram_path().path, analysis.output
 
 
 def _populate_participants(cohort: Cohort) -> None:

--- a/cpg_utils/workflows/inputs.py
+++ b/cpg_utils/workflows/inputs.py
@@ -8,7 +8,6 @@ from itertools import groupby
 
 from cpg_utils.config import get_config
 
-from .filetypes import GvcfPath, CramPath
 from .metamist import get_metamist, Sequence, AnalysisType, MetamistError
 from .targets import Cohort, Sex, PedigreeInfo
 
@@ -194,10 +193,14 @@ def _populate_analysis(cohort: Cohort) -> None:
         for sample in dataset.get_samples():
             if analysis := gvcf_by_sid.get(sample.id):
                 if analysis.output:
-                    assert analysis.output == sample.make_gvcf_path().path, analysis.output
+                    assert (
+                        analysis.output == sample.make_gvcf_path().path
+                    ), analysis.output
             if analysis := cram_by_sid.get(sample.id):
                 if analysis.output:
-                    assert analysis.output == sample.make_cram_path().path, analysis.output
+                    assert (
+                        analysis.output == sample.make_cram_path().path
+                    ), analysis.output
 
 
 def _populate_participants(cohort: Cohort) -> None:

--- a/cpg_utils/workflows/inputs.py
+++ b/cpg_utils/workflows/inputs.py
@@ -191,16 +191,13 @@ def _populate_analysis(cohort: Cohort) -> None:
             dataset=dataset.name,
         )
         for sample in dataset.get_samples():
-            if analysis := gvcf_by_sid.get(sample.id):
-                if analysis.output:
-                    assert (
-                        analysis.output == sample.make_gvcf_path().path
-                    ), analysis.output
-            if analysis := cram_by_sid.get(sample.id):
-                if analysis.output:
-                    assert (
-                        analysis.output == sample.make_cram_path().path
-                    ), analysis.output
+            if (analysis := gvcf_by_sid.get(sample.id)) and analysis.output:
+                assert analysis.output == sample.make_gvcf_path().path, (
+                    analysis.output,
+                    sample.make_gvcf_path().path,
+                )
+            if (analysis := cram_by_sid.get(sample.id)) and analysis.output:
+                assert analysis.output == sample.make_cram_path().path, analysis.output
 
 
 def _populate_participants(cohort: Cohort) -> None:

--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -179,9 +179,12 @@ class Metamist:
         """
         Query the DB to find the last completed joint-calling analysis for the samples.
         """
+        project = dataset or self.default_dataset
+        if get_config()['workflow']['access_level'] == 'test':
+            project += '-test'
         try:
             data = self.aapi.get_latest_complete_analysis_for_type(
-                project=dataset or self.default_dataset,
+                project=project,
                 analysis_type=models.AnalysisType('joint-calling'),
             )
         except ApiException:
@@ -209,15 +212,16 @@ class Metamist:
         sample (e.g. cram, gvcf).
         """
         dataset = dataset or self.default_dataset
+        project = dataset or self.default_dataset
+        if get_config()['workflow']['access_level'] == 'test':
+            project += '-test'
 
         analysis_per_sid: dict[str, Analysis] = dict()
 
-        logging.info(
-            f'Querying {analysis_type} analysis entries for dataset {dataset}...'
-        )
+        logging.info(f'Querying {analysis_type} analysis entries for {project}...')
         datas = self.aapi.query_analyses(
             models.AnalysisQueryModel(
-                projects=[dataset],
+                projects=[project],
                 sample_ids=sample_ids,
                 type=models.AnalysisType(analysis_type.value),
                 status=models.AnalysisStatus(analysis_status.value),
@@ -234,7 +238,7 @@ class Metamist:
             assert len(a.sample_ids) == 1, data
             analysis_per_sid[list(a.sample_ids)[0]] = a
         logging.info(
-            f'Querying {analysis_type} analysis entries for dataset {dataset}: '
+            f'Querying {analysis_type} analysis entries for {project}: '
             f'found {len(analysis_per_sid)}'
         )
         return analysis_per_sid
@@ -252,6 +256,9 @@ class Metamist:
         Tries to create an Analysis entry, returns its id if successful.
         """
         dataset = dataset or self.default_dataset
+        project = dataset or self.default_dataset
+        if get_config()['workflow']['access_level'] == 'test':
+            project += '-test'
 
         if isinstance(type_, AnalysisType):
             type_ = type_.value
@@ -266,14 +273,14 @@ class Metamist:
             meta=meta or {},
         )
         try:
-            aid = self.aapi.create_new_analysis(project=dataset, analysis_model=am)
+            aid = self.aapi.create_new_analysis(project=project, analysis_model=am)
         except ApiException:
             traceback.print_exc()
             return None
         else:
             logging.info(
                 f'Created Analysis(id={aid}, type={type_}, status={status}, '
-                f'output={str(output)}) in project {dataset}'
+                f'output={str(output)}) in {project}'
             )
             return aid
 
@@ -298,7 +305,7 @@ class Metamist:
         @param analysis_type: cram, gvcf, joint_calling
         @param expected_output_fpath: where the workflow expects the analysis output
         file to sit on the bucket (will invalidate the analysis when it doesn't match)
-        @param dataset: the name of the project where to create a new analysis
+        @param dataset: the name of the dataset to create a new analysis
         @return: path to the output if it can be reused, otherwise None
         """
         label = f'type={analysis_type}'
@@ -480,6 +487,8 @@ class Sequence:
                     f'.cram or .bam, got: {location}'
                 )
                 return None
+            if get_config()['workflow']['access_level'] == 'test':
+                location = location.replace('-main-upload/', '-test-upload/')
             if check_existence and not exists(location):
                 logging.error(
                     f'{sample_id}: ERROR: index file does not exist: {location}'
@@ -499,6 +508,10 @@ class Sequence:
                     logging.error(
                         f'{sample_id}: ERROR: expected the index file to have an extension '
                         f'.crai or .bai, got: {index_location}'
+                    )
+                if get_config()['workflow']['access_level'] == 'test':
+                    index_location = index_location.replace(
+                        '-main-upload/', '-test-upload/'
                     )
                 if check_existence and not exists(index_location):
                     logging.error(
@@ -525,6 +538,13 @@ class Sequence:
                         f'formatted. Expecting 2 entries per lane (R1 and R2 fastqs), '
                         f'but got {len(lane_pair)}. '
                         f'Read data: {pprint.pformat(reads_data)}'
+                    )
+                if get_config()['workflow']['access_level'] == 'test':
+                    lane_pair[0]['location'] = lane_pair[0]['location'].replace(
+                        '-main-upload/', '-test-upload/'
+                    )
+                    lane_pair[1]['location'] = lane_pair[1]['location'].replace(
+                        '-main-upload/', '-test-upload/'
                     )
                 if check_existence and not exists(lane_pair[0]['location']):
                     logging.error(

--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -512,7 +512,8 @@ class Sequence:
                     index_path=index_location,
                     reference_assembly=reference_assembly,
                 )
-            if location.endswith('.bam'):
+            else:
+                assert location.endswith('.bam')
                 return BamPath(location, index_path=index_location)
 
         else:

--- a/cpg_utils/workflows/targets.py
+++ b/cpg_utils/workflows/targets.py
@@ -9,13 +9,14 @@ from enum import Enum
 from typing import Optional
 import pandas as pd
 
-from cpg_utils.hail_batch import dataset_path, web_url
+from cpg_utils.hail_batch import dataset_path, web_url, reference_path
 from cpg_utils.config import get_config
 from cpg_utils import Path, to_path
 
 from .filetypes import (
     AlignmentInput,
     CramPath,
+    BamPath,
     GvcfPath,
     FastqPairs,
 )
@@ -493,10 +494,9 @@ class Sample(Target):
         for seq_type, alignment_input in self.alignment_input_by_seq_type.items():
             ai_tag += f'|SEQ={seq_type}:'
             if isinstance(alignment_input, CramPath):
-                if alignment_input.is_bam:
-                    ai_tag += 'CRAM'
-                else:
-                    ai_tag += 'BAM'
+                ai_tag += 'CRAM'
+            elif isinstance(alignment_input, BamPath):
+                ai_tag += 'BAM'
             else:
                 assert isinstance(alignment_input, FastqPairs)
                 ai_tag += f'{len(alignment_input)}FQS'
@@ -554,7 +554,12 @@ class Sample(Target):
         """
         Path to a CRAM file. Not checking its existence here.
         """
-        return CramPath(self.dataset.prefix() / 'cram' / f'{self.id}.cram')
+        path = self.dataset.prefix() / 'cram' / f'{self.id}.cram'
+        return CramPath(
+            path=path,
+            index_path=path.with_suffix('.cram.crai'),
+            reference_assembly=reference_path('broad/ref_fasta'),
+        )
 
     def make_gvcf_path(self, access_level: str | None = None) -> GvcfPath:
         """

--- a/cpg_utils/workflows/targets.py
+++ b/cpg_utils/workflows/targets.py
@@ -550,11 +550,13 @@ class Sample(Target):
             'Phenotype': '0',
         }
 
-    def make_cram_path(self) -> CramPath:
+    def make_cram_path(self, access_level: str | None = None) -> CramPath:
         """
         Path to a CRAM file. Not checking its existence here.
         """
-        path = self.dataset.prefix() / 'cram' / f'{self.id}.cram'
+        path = (
+            self.dataset.prefix(access_level=access_level) / 'cram' / f'{self.id}.cram'
+        )
         return CramPath(
             path=path,
             index_path=path.with_suffix('.cram.crai'),

--- a/cpg_utils/workflows/workflow.py
+++ b/cpg_utils/workflows/workflow.py
@@ -474,12 +474,12 @@ class Stage(Generic[TargetT], ABC):
         Collects outputs from all dependencies and create input for this stage
         """
         inputs = StageInput(self)
-        logging.info(f'_make_inputs stage={self}')
+        logging.debug(f'Stage._make_inputs stage={self}')
         for prev_stage in self.required_stages:
-            logging.info(f'_make_inputs stage={self}, prev_stage={prev_stage}')
+            logging.debug(f'Stage._make_inputs stage={self}, prev_stage={prev_stage}')
             for _, stage_output in prev_stage.output_by_target.items():
-                logging.info(
-                    f'_make_inputs stage={self}, prev_stage={prev_stage}, stage_output={stage_output}'
+                logging.debug(
+                    f'Stage._make_inputs stage={self}, prev_stage={prev_stage}, stage_output={stage_output}'
                 )
                 if stage_output:
                     inputs.add_other_stage_output(stage_output)


### PR DESCRIPTION
* Currently `CramPath` implicitly sets the path to the `.crai` index if it's not provided explicitly. That doesn't work nicely when the file is pulled from metamist as sequencing input, which can have or can miss the index, and it can cause error like as follows: https://batch.hail.populationgenomics.org.au/batches/182650/jobs/1 Changing logic to setting the index explicitly, and requiring index to be specified in metamist in `secondaryFiles`.
* Currently `CramPath` represents both BAM and CRAM files, with a `is_bam` flag. It's a bit confusing and error prone, so splitting those into two separate classes.