### PR TITLE
Support filtering samples by batch number

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.6.1
+current_version = 4.6.2
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.6.1',
+    version='4.6.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Useful for large-cohort datasets.

Batch IDs are set in the config, similar to `only_samples`:

```toml
[workflow]
only_batches = [1, 2]
```