### PR TITLE
Batch: avoid coping configs to remote for dry run

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.7.0
+current_version = 4.7.1
 commit = True
 tag = False
 

--- a/cpg_utils/config-template.toml
+++ b/cpg_utils/config-template.toml
@@ -149,9 +149,6 @@ sm-api = 'driver:14432044df1c5210237727cc10bee817674700c0-hail-48ff6e3a3f08a11cc
 # Genome build. Only GRCh38 is currently supported.
 genome_build = 'GRCh38'
 
-# Paths to reference files. Paths can be absolute
-# or relative to the `workflow.reference_prefix` config option.
-
 # Site list for somalier https://github.com/brentp/somalier/releases/tag/v0.2.15
 somalier_sites = 'somalier/v0/sites.hg38.vcf.gz'
 # Somalier 1kg data for the "ancestry" command

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.7.0',
+    version='4.7.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Useful for tests, which use local backend or dry_run.