### PR TITLE
Revert reference override

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.7.1
+current_version = 4.8.0
 commit = True
 tag = False
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -40,9 +40,9 @@ def init_batch(**kwargs):
         return  # already initialised
     dataset = get_config()['workflow']['dataset']
     kwargs.setdefault('token', os.environ.get('HAIL_TOKEN'))
-    kwargs.setdefault('default_reference', genome_build())
     asyncio.get_event_loop().run_until_complete(
         hl.init_batch(
+            default_reference=genome_build(),
             billing_project=get_config()['hail']['billing_project'],
             remote_tmpdir=remote_tmpdir(f'cpg-{dataset}-hail'),
             **kwargs,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.7.1',
+    version='4.8.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Reverting in favour of adding this line to the analysis-runner invocation. Basically it just asks analysis-runner to override the reference.genome_build parameter. You can pass a file, eg:

`grch37.yoml`
```toml
[reference]
genome_build = "GRCh37"
```

`analysis-runner --config grch37.toml [...]`

You can do this inline with process-substitution too, eg:

```shell
analysis-runner \
    --config <(echo '[references]\ngenome_build = "GRCh37"') \
    [...]
```