### PR TITLE
Fix ped call

### DIFF
--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -454,7 +454,7 @@ class Metamist:
         family_ids = [family['id'] for family in families]
         ped_entries = self.fapi.get_pedigree(
             internal_family_ids=family_ids,
-            response_type='json',
+            export_type='json',
             project=metamist_proj,
             replace_with_participant_external_ids=True,
         )


### PR DESCRIPTION
This change was initially made here https://github.com/populationgenomics/cpg-utils/pull/80, but got missed

As per the docs https://sample-metadata.populationgenomics.org.au/documentation/FamilyApi.md#get_pedigree