### PR TITLE
Workflows: inputs: populate participant metadata

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.8.15
+current_version = 4.8.16
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.8.15
+  VERSION: 4.8.16
 
 jobs:
   docker:

--- a/cpg_utils/workflows/inputs.py
+++ b/cpg_utils/workflows/inputs.py
@@ -185,7 +185,7 @@ def _populate_participants(cohort: Cohort) -> None:
         for sample in dataset.get_samples():
             if entry := participant_entry_by_sid.get(sample.id):
                 sample.participant_id = entry['external_id']
-                if reported_sex := entry['reported_sex']:
+                if reported_sex := entry.get('reported_sex'):
                     sample.pedigree.sex = Sex.parse(reported_sex)
                 update_dict(sample.meta, entry.get('meta', {}))
 

--- a/cpg_utils/workflows/inputs.py
+++ b/cpg_utils/workflows/inputs.py
@@ -186,15 +186,7 @@ def _populate_participants(cohort: Cohort) -> None:
             if entry := participant_entry_by_sid.get(sample.id):
                 sample.participant_id = entry['external_id']
                 if reported_sex := entry['reported_sex']:
-                    sex = Sex.parse(reported_sex)
-                    if sample.pedigree:
-                        sample.pedigree.sex = sex
-                    else:
-                        sample.pedigree = PedigreeInfo(
-                            sample=sample,
-                            fam_id=sample.participant_id,
-                            sex=sex,
-                        )
+                    sample.pedigree.sex = Sex.parse(reported_sex)
                 update_dict(sample.meta, entry.get('meta', {}))
 
 
@@ -240,10 +232,3 @@ def _populate_pedigree(cohort: Cohort) -> None:
                 f'No pedigree data found for '
                 f'{len(sids_wo_ped)}/{len(dataset.get_samples())} samples'
             )
-
-    for dataset in cohort.get_datasets():
-        samples_with_ped = [s for s in dataset.get_samples() if s.pedigree]
-        logging.info(
-            f'{dataset.name}: found pedigree info for {len(samples_with_ped)} '
-            f'samples out of {len(dataset.get_samples())}'
-        )

--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -200,7 +200,7 @@ class Metamist:
             entries_by_sid[entry['sample_id']].append(entry)
         return entries_by_sid
 
-    def get_participant_entries_by_sid(self, dataset_name: str) -> dict[str, str]:
+    def get_participant_entries_by_sid(self, dataset_name: str) -> dict[str, dict]:
         """
         Retrieve participant entries for a dataset, in the context of access level.
         """
@@ -211,12 +211,18 @@ class Metamist:
         pid_sid_multi = self.papi.get_external_participant_id_to_internal_sample_id(
             metamist_proj
         )
-        participant_by_sid = {}
+        sid_by_pid = {}
         for group in pid_sid_multi:
-            pid = group[0]
+            pid = group[0].strip()
             for sid in group[1:]:
-                participant_by_sid[sid] = pid.strip()
-        return participant_by_sid
+                sid_by_pid[pid] = sid
+
+        entries = self.papi.get_participants(metamist_proj)
+        participant_entry_by_sid = {}
+        for entry in entries:
+            pid = sid_by_pid[entry['external_id']]
+            participant_entry_by_sid = {sid_by_pid[pid]: entry}
+        return participant_entry_by_sid
 
     def update_analysis(self, analysis: Analysis, status: AnalysisStatus):
         """

--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -220,8 +220,7 @@ class Metamist:
         entries = self.papi.get_participants(metamist_proj)
         participant_entry_by_sid = {}
         for entry in entries:
-            pid = sid_by_pid[entry['external_id']]
-            participant_entry_by_sid = {sid_by_pid[pid]: entry}
+            participant_entry_by_sid[sid_by_pid[entry['external_id']]] = entry
         return participant_entry_by_sid
 
     def update_analysis(self, analysis: Analysis, status: AnalysisStatus):

--- a/cpg_utils/workflows/targets.py
+++ b/cpg_utils/workflows/targets.py
@@ -613,17 +613,17 @@ class PedigreeInfo:
     sample: Sample
     sex: Sex = Sex.UNKNOWN
     fam_id: str | None = None
-    phenotype: str = '0'
+    phenotype: str | int = 0
     dad: Sample | None = None
     mom: Sample | None = None
 
-    def get_ped_dict(self, use_participant_id: bool = False) -> dict:
+    def get_ped_dict(self, use_participant_id: bool = False) -> dict[str, str]:
         """
         Returns a dictionary of pedigree fields for this sample, corresponding
         a PED file entry.
         """
 
-        def _get_id(_s: Sample | None):
+        def _get_id(_s: Sample | None) -> str:
             if _s is None:
                 return '0'
             if use_participant_id:
@@ -636,5 +636,5 @@ class PedigreeInfo:
             'Father.ID': _get_id(self.dad),
             'Mother.ID': _get_id(self.mom),
             'Sex': str(self.sex.value),
-            'Phenotype': self.phenotype,
+            'Phenotype': str(self.phenotype),
         }

--- a/cpg_utils/workflows/targets.py
+++ b/cpg_utils/workflows/targets.py
@@ -418,16 +418,17 @@ class Sex(Enum):
     FEMALE = 2
 
     @staticmethod
-    def parse(sex: str | None) -> 'Sex':
+    def parse(sex: str | int | None) -> 'Sex':
         """
         Parse a string into a Sex object.
         """
         if sex:
-            if sex.lower() in ('m', 'male', '1'):
+            _sex = sex.lower() if isinstance(sex, str) else sex
+            if _sex in ('m', 'male', '1', 1):
                 return Sex.MALE
-            if sex.lower() in ('f', 'female', '2'):
+            if _sex in ('f', 'female', '2', 2):
                 return Sex.FEMALE
-            if sex.lower() in ('u', 'unknown', '0'):
+            if _sex in ('u', 'unknown', '0', 0):
                 return Sex.UNKNOWN
             raise ValueError(f'Unrecognised sex value {sex}')
         return Sex.UNKNOWN

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.8.15',
+    version='4.8.16',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -142,4 +142,5 @@ def test_cohort(mocker: MockFixture):
     cohort = get_cohort()
     assert cohort.get_samples()[0].id == 'CPG01'
     assert cohort.get_samples()[0].meta['Superpopulation name'] == 'Africa'
+    assert cohort.get_samples()[0].pedigree
     assert cohort.get_samples()[0].pedigree.sex == Sex.MALE

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -143,5 +143,5 @@ def test_cohort(mocker: MockFixture):
     assert cohort.get_samples()[0].id == 'CPG01'
     assert cohort.get_samples()[0].meta['Superpopulation name'] == 'Africa'
     assert cohort.get_samples()[0].pedigree
-    if cohort.get_samples()[0].pedigree:
+    if cohort.get_samples()[0].pedigree is not None:
         assert cohort.get_samples()[0].pedigree.sex == Sex.MALE

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -142,6 +142,4 @@ def test_cohort(mocker: MockFixture):
     cohort = get_cohort()
     assert cohort.get_samples()[0].id == 'CPG01'
     assert cohort.get_samples()[0].meta['Superpopulation name'] == 'Africa'
-    assert cohort.get_samples()[0].pedigree
-    if cohort.get_samples()[0].pedigree is not None:
-        assert cohort.get_samples()[0].pedigree.sex == Sex.MALE
+    assert cohort.get_samples()[0].pedigree.sex == Sex.MALE

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -143,4 +143,5 @@ def test_cohort(mocker: MockFixture):
     assert cohort.get_samples()[0].id == 'CPG01'
     assert cohort.get_samples()[0].meta['Superpopulation name'] == 'Africa'
     assert cohort.get_samples()[0].pedigree
-    assert cohort.get_samples()[0].pedigree.sex == Sex.MALE
+    if cohort.get_samples()[0].pedigree:
+        assert cohort.get_samples()[0].pedigree.sex == Sex.MALE


### PR DESCRIPTION
Currently we only populate participant IDs. But we also want other participant metadata (`reported_sex`, `meta` that would contain ancestry labels for large cohort pipeline, etc). Making sure it's read from metamist into sample objects.

* Make `sample.pedigree` non-optional
* If `Participant.reported_sex` is available, set `sample.pedigree.sex`
* Merge `Participant.meta` into `sample.meta`
* In largo cohort pipeline, use `pop_meta_field` to extract known pop labels with `sample.meta[pop_meta_field]`