### PR TITLE
Workflows: inputs: handle dummy participants and sequences with no reads

### DIFF
--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -222,11 +222,10 @@ class Metamist:
         for entry in entries:
             pid = entry['external_id']
             if not (sid := sid_by_pid.get(pid)):
-                raise MetamistError(
-                    f'papi.get_participants returned participant that was not returned '
-                    f'by papi.get_external_participant_id_to_internal_sample_id: '
-                    f'{entry}'
-                )
+                # This is an expected behaviour: dummy participant entries might be
+                # created to fill in the PED data. We should just ignore participants
+                # with no associated samples.
+                continue
             participant_entry_by_sid[sid] = entry
         return participant_entry_by_sid
 
@@ -513,13 +512,11 @@ class Sequence:
             meta=data['meta'],
             sequencing_type=sequencing_type,
         )
-        alignment_input = Sequence._parse_reads(
+        mm_seq.alignment_input = Sequence._parse_reads(
             sample_id=sample_id,
             meta=data['meta'],
             check_existence=check_existence,
         )
-        assert alignment_input, (sample_id, data)
-        mm_seq.alignment_input = alignment_input
         return mm_seq
 
     @staticmethod

--- a/cpg_utils/workflows/status.py
+++ b/cpg_utils/workflows/status.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 from abc import ABC, abstractmethod
 
 from cpg_utils import Path
-from cpg_utils.hail_batch import command
+from cpg_utils.hail_batch import command, image_path
 from hailtop.batch.job import Job
 from hailtop.batch import Batch, Resource
 
@@ -152,7 +152,7 @@ class MetamistStatusReporter(StatusReporter):
             job_name += f' (for {analysis_type})'
 
         j = b.new_job(job_name, job_attrs)
-        j.image(get_config()['workflow']['driver_image'])
+        j.image(image_path('cpg_utils'))
 
         calc_size_cmd = None
         if output_path:

--- a/cpg_utils/workflows/status.py
+++ b/cpg_utils/workflows/status.py
@@ -12,7 +12,6 @@ from hailtop.batch import Batch, Resource
 
 from .targets import Target
 from .metamist import get_metamist, AnalysisStatus, MetamistError
-from ..config import get_config
 
 
 class StatusReporter(ABC):

--- a/test/test_cohort.py
+++ b/test/test_cohort.py
@@ -225,9 +225,12 @@ def test_cohort(mocker: MockFixture):
 
     cohort = get_cohort()
     # the 5th sample doesn't have associated seq/meta/reads
-    assert len(cohort.get_samples()) == 4
-    assert cohort.get_sample_ids() == ['CPG00', 'CPG01', 'CPG02', 'CPG03']
+    assert len(cohort.get_samples()) == 5
+    assert cohort.get_sample_ids() == ['CPG00', 'CPG01', 'CPG02', 'CPG03', 'CPG04']
     assert cohort.get_samples()[0].id == 'CPG00'
+    assert isinstance(
+        cohort.get_samples()[0].alignment_input_by_seq_type['genome'], BamPath
+    )
     assert isinstance(
         cohort.get_samples()[0].alignment_input_by_seq_type['genome'], BamPath
     )
@@ -245,3 +248,4 @@ def test_cohort(mocker: MockFixture):
     assert cohort.get_samples()[3].pedigree.sex == Sex.UNKNOWN
     assert cohort.get_samples()[3].pedigree.mom is None
     assert cohort.get_samples()[3].pedigree.dad is None
+    assert cohort.get_samples()[4].seq_by_type['genome'].alignment_input is None


### PR DESCRIPTION
* Dummy participant may be created to fill in PED entries that are not associated with samples. We want to ignore such participant entries.
* Sequences with no `meta.reads` might exist, we still want to create `sample.seq` in case there is useful metadata in `Sequence.meta` (e.g. QC for thousand-genomes).