### PR TITLE
[workflows] inputs: gather errors of missing seq/reads entries

### DIFF
--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -492,7 +492,11 @@ class Sequence:
     alignment_input: AlignmentInput | None = None
 
     @staticmethod
-    def parse(data: dict, check_existence: bool = False) -> 'Sequence':
+    def parse(
+        data: dict,
+        check_existence: bool = False,
+        parse_reads: bool = True,
+    ) -> 'Sequence':
         """
         Create from a dictionary.
         """
@@ -512,23 +516,23 @@ class Sequence:
             meta=data['meta'],
             sequencing_type=sequencing_type,
         )
-        mm_seq.alignment_input = Sequence._parse_reads(
-            sample_id=sample_id,
-            meta=data['meta'],
-            check_existence=check_existence,
-        )
+        if parse_reads:
+            mm_seq.alignment_input = Sequence.parse_reads(
+                sample_id=sample_id,
+                meta=data['meta'],
+                check_existence=check_existence,
+            )
         return mm_seq
 
     @staticmethod
-    def _parse_reads(  # pylint: disable=too-many-return-statements
+    def parse_reads(  # pylint: disable=too-many-return-statements
         sample_id: str,
         meta: dict,
         check_existence: bool,
-    ) -> AlignmentInput | None:
+    ) -> AlignmentInput:
         """
         Parse a AlignmentInput object from the meta dictionary.
-
-        @param check_existence: check if fastq/crams exist on buckets.
+        `check_existence`: check if fastq/crams exist on buckets.
         Default value is pulled from self.metamist and can be overridden.
         """
         reads_data = meta.get('reads')
@@ -536,38 +540,34 @@ class Sequence:
         reference_assembly = meta.get('reference_assembly', {}).get('location')
 
         if not reads_data:
-            logging.error(f'{sample_id}: no "meta/reads" field in meta')
-            return None
+            raise MetamistError(f'{sample_id}: no "meta/reads" field in meta')
         if not reads_type:
-            logging.error(f'{sample_id}: no "meta/reads_type" field in meta')
-            return None
+            raise MetamistError(f'{sample_id}: no "meta/reads_type" field in meta')
         supported_types = ('fastq', 'bam', 'cram')
         if reads_type not in supported_types:
-            logging.error(
+            raise MetamistError(
                 f'{sample_id}: ERROR: "reads_type" is expected to be one of '
                 f'{supported_types}'
             )
-            return None
 
         if reads_type in ('bam', 'cram'):
             if len(reads_data) > 1:
-                logging.error(f'{sample_id}: supporting only single bam/cram input')
-                return None
+                raise MetamistError(
+                    f'{sample_id}: supporting only single bam/cram input'
+                )
 
             location = reads_data[0]['location']
             if not (location.endswith('.cram') or location.endswith('.bam')):
-                logging.error(
+                raise MetamistError(
                     f'{sample_id}: ERROR: expected the file to have an extension '
                     f'.cram or .bam, got: {location}'
                 )
-                return None
             if get_config()['workflow']['access_level'] == 'test':
                 location = location.replace('-main-upload/', '-test-upload/')
             if check_existence and not exists(location):
-                logging.error(
+                raise MetamistError(
                     f'{sample_id}: ERROR: index file does not exist: {location}'
                 )
-                return None
 
             # Index:
             index_location = None
@@ -579,7 +579,7 @@ class Sequence:
                     or location.endswith('.bai')
                     and not index_location.endswith('.bai')
                 ):
-                    logging.error(
+                    raise MetamistError(
                         f'{sample_id}: ERROR: expected the index file to have an extension '
                         f'.crai or .bai, got: {index_location}'
                     )
@@ -588,10 +588,9 @@ class Sequence:
                         '-main-upload/', '-test-upload/'
                     )
                 if check_existence and not exists(index_location):
-                    logging.error(
+                    raise MetamistError(
                         f'{sample_id}: ERROR: index file does not exist: {index_location}'
                     )
-                    return None
 
             if location.endswith('.cram'):
                 return CramPath(
@@ -621,17 +620,15 @@ class Sequence:
                         '-main-upload/', '-test-upload/'
                     )
                 if check_existence and not exists(lane_pair[0]['location']):
-                    logging.error(
+                    raise MetamistError(
                         f'{sample_id}: ERROR: read 1 file does not exist: '
                         f'{lane_pair[0]["location"]}'
                     )
-                    return None
                 if check_existence and not exists(lane_pair[1]['location']):
-                    logging.error(
+                    raise MetamistError(
                         f'{sample_id}: ERROR: read 2 file does not exist: '
                         f'{lane_pair[1]["location"]}'
                     )
-                    return None
 
                 fastq_pairs.append(
                     FastqPair(


### PR DESCRIPTION
E.g. for thousand-genomes it would print:
```
WARNING:root:Found 3202/3202 samples with no meta/reads in corresponding sequence entries
```
Instead of 3202 repetitive lines.

But if `meta/reads` exist, we should expect it to have correct read data, so the code would do all the validation needed and throw errors early for samples separately, which is useful for debugging.