### PR TITLE
When `workflow/output_version` not set, use alignments hash rather than timestamp

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.9.1
+current_version = 4.9.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 4.9.1
+  VERSION: 4.9.2
 
 jobs:
   docker:

--- a/cpg_utils/workflows/metamist.py
+++ b/cpg_utils/workflows/metamist.py
@@ -487,8 +487,9 @@ class Metamist:
         chunk_size = 500
         for i, fam_ids_chunk in enumerate(_chunks(family_ids, chunk_size)):
             logging.info(
-                f'Running fapi.get_pedigree on families #{i * chunk_size}..'
-                f'{i * chunk_size + 1 + len(fam_ids_chunk)} (out of {len(family_ids)})'
+                f'Running fapi.get_pedigree on families #{i * chunk_size + 1}..'
+                f'{i * chunk_size + 1 + len(fam_ids_chunk) - 1} '
+                f'(out of {len(family_ids)})'
             )
             ped_entries.extend(
                 self.fapi.get_pedigree(

--- a/cpg_utils/workflows/utils.py
+++ b/cpg_utils/workflows/utils.py
@@ -117,7 +117,7 @@ def slugify(line: str):
     """
 
     return re.sub(
-        r'[-\s]+',
+        r'[-.\s]+',
         '-',
         re.sub(
             r'[^\w\s-]',

--- a/cpg_utils/workflows/utils.py
+++ b/cpg_utils/workflows/utils.py
@@ -116,17 +116,14 @@ def slugify(line: str):
     'hello-w-1'
     """
 
-    return re.sub(
-        r'[-.\s]+',
+    line = unicodedata.normalize('NFKD', line).encode('ascii', 'ignore').decode()
+    line = line.strip().lower()
+    line = re.sub(
+        r'[\s.]+',
         '-',
-        re.sub(
-            r'[^\w\s-]',
-            '',
-            unicodedata.normalize('NFKD', line).encode('ascii', 'ignore').decode(),
-        )
-        .strip()
-        .lower(),
+        line,
     )
+    return line
 
 
 def rich_sample_id_seds(

--- a/cpg_utils/workflows/utils.py
+++ b/cpg_utils/workflows/utils.py
@@ -112,8 +112,8 @@ def slugify(line: str):
     Slugify a string.
 
     Example:
-    >>> slugify(u"Héllø Wörld")
-    u"hello-world"
+    >>> slugify(u'Héllø W.1')
+    'hello-w-1'
     """
 
     return re.sub(

--- a/cpg_utils/workflows/workflow.py
+++ b/cpg_utils/workflows/workflow.py
@@ -765,10 +765,7 @@ class Workflow:
 
     def _prefix(self, category=None) -> Path:
         prefix = get_cohort().analysis_dataset.prefix(category=category) / self.name
-        if self.output_version:
-            prefix /= self.output_version
-        else:
-            prefix /= self.run_timestamp
+        prefix /= self.output_version or get_cohort().alignment_inputs_hash()
         return prefix
 
     def run(

--- a/cpg_utils/workflows/workflow.py
+++ b/cpg_utils/workflows/workflow.py
@@ -547,7 +547,10 @@ class Stage(Generic[TargetT], ABC):
                 )
                 return Action.QUEUE
             else:
-                logging.info(f'{self.name}: {target} [REUSE] (expected outputs exist)')
+                logging.info(
+                    f'{self.name}: {target} [REUSE] (expected outputs exist: '
+                    f'{expected_out})'
+                )
                 return Action.REUSE
 
         logging.info(f'{self.name}: {target} [QUEUE]')

--- a/cpg_utils/workflows/workflow.py
+++ b/cpg_utils/workflows/workflow.py
@@ -99,20 +99,20 @@ class StageOutput:
         )
         return res
 
-    def as_path(self, id=None) -> Path:
+    def as_path(self, key=None) -> Path:
         """
         Cast the result to a path object. Throw an exception when can't cast.
-        `id` is used to extract the value when the result is a dictionary.
+        `key` is used to extract the value when the result is a dictionary.
         """
         if self.data is None:
             raise ValueError(f'{self.stage}: output data is not available')
 
-        if id is not None:
+        if key is not None:
             if not isinstance(self.data, dict):
                 raise ValueError(
-                    f'{self.stage}: {self.data} is not a dictionary, can\'t get "{id}"'
+                    f'{self.stage}: {self.data} is not a dictionary, can\'t get "{key}"'
                 )
-            res = cast(dict, self.data)[id]
+            res = cast(dict, self.data)[key]
         else:
             res = self.data
 
@@ -197,12 +197,12 @@ class StageInput:
     def as_path_by_target(
         self,
         stage: StageDecorator,
-        id: str | None = None,
+        key: str | None = None,
     ) -> dict[str, Path]:
         """
         Get a single file path result, indexed by target for a specific stage
         """
-        return self._each(fun=(lambda r: r.as_path(id=id)), stage=stage)
+        return self._each(fun=(lambda r: r.as_path(key=key)), stage=stage)
 
     def as_dict_by_target(self, stage: StageDecorator) -> dict[str, dict[str, Path]]:
         """
@@ -240,14 +240,14 @@ class StageInput:
         self,
         target: 'Target',
         stage: StageDecorator,
-        id: str | None = None,
+        key: str | None = None,
     ) -> Path:
         """
         Represent as a path to a file, otherwise fail.
         `stage` can be callable, or a subclass of Stage
         """
         res = self._get(target=target, stage=stage)
-        return res.as_path(id)
+        return res.as_path(key)
 
     def as_dict(self, target: 'Target', stage: StageDecorator) -> dict[str, Path]:
         """

--- a/cpg_utils/workflows/workflow.py
+++ b/cpg_utils/workflows/workflow.py
@@ -997,7 +997,7 @@ class SampleStage(Stage[Sample], ABC):
             )
             return output_by_target
 
-        for ds_i, dataset in enumerate(datasets):
+        for dataset in datasets:
             if not dataset.get_samples():
                 logging.warning(
                     f'{dataset}: '
@@ -1011,7 +1011,7 @@ class SampleStage(Stage[Sample], ABC):
                 continue
 
             logging.info(f'Dataset {dataset}:')
-            for sample_i, sample in enumerate(dataset.get_samples()):
+            for sample in dataset.get_samples():
                 action = self._get_action(sample)
                 output_by_target[sample.target_id] = self._queue_jobs_with_checks(
                     sample, action

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.9.1',
+    version='4.9.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Prefix stage outputs with a hash of all alignments inputs.

In other words, defaulting to _reusing_ any existing intermediates to rerunning everything. Seems like a more reasonable default for heavy workflows.