### PR TITLE
Hail Batch command wrapper: activate gcloud creds when `define_retry_function`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.10.0
+current_version = 4.10.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 4.10.0
+  VERSION: 4.10.1
 
 jobs:
   docker:

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -528,6 +528,9 @@ def command(
     if isinstance(cmd, list):
         cmd = '\n'.join(cmd)
 
+    if define_retry_function:
+        setup_gcp = True
+
     cmd = f"""\
     set -o pipefail
     set -ex

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.10.0',
+    version='4.10.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Since custom localisation uses `gsutil`, google cloud credentials must be activated.