### PR TITLE
Configs: handy functions to prepend and append; more validation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.10.2
+current_version = 4.10.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 4.10.2
+  VERSION: 4.10.3
 
 jobs:
   docker:

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -25,7 +25,7 @@ def _validate_configs(config_paths: list[str]) -> None:
         raise ValueError(f'Some config files do not exist: {bad_paths}')
 
     # Reading each file to validate syntax:
-    exception_by_path = dict()
+    exception_by_path = {}
     for p in paths:
         with p.open() as f:
             try:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.10.2',
+    version='4.10.3',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
* Add `append_config_paths` and `prepend_config_paths` in addition to `set_config_paths`
* Into `_validate_configs`, added some actual validation: parsing of all tomls and reporting errors