### PR TITLE
`fasta_res_group` only points to unmasked reference

### DIFF
--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -295,10 +295,7 @@ def fasta_res_group(b: hb.Batch, indices: list[str] | None = None):
     @param b: Hail Batch object.
     @param indices: list of extensions to add to the base fasta file path.
     """
-    ref_fasta = get_config()['workflow'].get('ref_fasta') or reference_path(
-        'broad/ref_fasta'
-    )
-    ref_fasta = to_path(ref_fasta)
+    ref_fasta = reference_path('broad/ref_fasta')
     d = dict(
         base=str(ref_fasta),
         fai=str(ref_fasta) + '.fai',


### PR DESCRIPTION
The only place where masked reference is used is in `dragen-os` call, following the WARP design:
https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/jobs/align.py#L445

Following up on https://github.com/populationgenomics/references/pull/12/files