### PR TITLE
Make printing the configuration optional

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.12.1
+current_version = 4.12.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 4.12.1
+  VERSION: 4.12.2
 
 jobs:
   docker:

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -84,7 +84,7 @@ def append_config_paths(config_paths: list[str]) -> None:
     set_config_paths(config_paths)
 
 
-def get_config() -> frozendict:
+def get_config(print_config=True) -> frozendict:
     """Returns the configuration dictionary.
 
     Call `set_config_paths` beforehand to override the default path.
@@ -108,9 +108,10 @@ def get_config() -> frozendict:
         _config = read_configs(_config_paths)
 
         # Print the config content, which is helpful for debugging.
-        print(
-            f'Configuration at {",".join(_config_paths)}:\n{toml.dumps(dict(_config))}'
-        )
+        if print_config:
+            print(
+                f'Configuration at {",".join(_config_paths)}:\n{toml.dumps(dict(_config))}'
+            )
 
     return _config
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.12.1',
+    version='4.12.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Clogs my logging for cpg-infrastructure, but I like using the library. I think it's reasonable to silence the logging but discourage people from doing so.