### PR TITLE
OIDC ID token generation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.15.0
+current_version = 4.15.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  VERSION: 4.15.0
+  VERSION: 4.15.1
 
 jobs:
   docker:

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -22,6 +22,7 @@ from google.auth._default import (
     _EXTERNAL_ACCOUNT_TYPE,
 )
 from google.auth.transport import requests
+
 # pylint: disable=no-name-in-module
 from google.cloud import secretmanager
 from google.oauth2 import credentials as oauth2_credentials, service_account
@@ -159,15 +160,16 @@ class ExternalCredentialsAdapter(google_auth_credentials.Credentials):
     Wrapper around ExternalCredentials because I (mfranklin) cannot work out how to
     make the python version work, and have defaulted to using the gcloud command line.
     """
+
     def __init__(
         self,
         audience: str | None,
-        impersonate_id: str | None = os.getenv('GOOGLE_IMPERSONATE_IDENTITY'),
+        impersonate_id: str | None = None,
     ):
         super().__init__()
         self.token = None
         self.audience = audience
-
+        impersonate_id = impersonate_id or os.environ.get('GOOGLE_IMPERSONATE_IDENTITY')
         if not impersonate_id:
             raise exceptions.DefaultCredentialsError(
                 f'GOOGLE_IMPERSONATE_IDENTITY environment variable is not set. '
@@ -176,7 +178,7 @@ class ExternalCredentialsAdapter(google_auth_credentials.Credentials):
 
         self.impersonate_id = impersonate_id
 
-    def refresh(self, *args, **kwargs):
+    def refresh(self, *args, **kwargs):  # pylint: disable=unused-argument
         """Call gcloud to get a new token."""
         command = [
             'gcloud',

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -182,11 +182,11 @@ class ExternalCredentialsAdapter(google_auth_credentials.Credentials):
             'gcloud',
             'auth',
             'print-identity-token',
-            f'--impersonate-service-account="{self.impersonate_id}"',
+            f'--impersonate-service-account={self.impersonate_id}',
             '--include-email',
         ]
         if self.audience:
-            command.append(f'--audiences="{self.audience}"')
+            command.append(f'--audiences={self.audience}')
 
         self.token = subprocess.check_output(command).decode('utf-8').strip()
 

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -14,7 +14,9 @@ from google.auth import jwt
 from google.auth._default import (
     _AUTHORIZED_USER_TYPE,
     _SERVICE_ACCOUNT_TYPE,
+    _EXTERNAL_ACCOUNT_TYPE,
     _VALID_TYPES,
+    _get_external_account_credentials,
 )
 
 # pylint: disable=no-name-in-module
@@ -191,6 +193,10 @@ def _load_credentials_from_file(
             raise exceptions.DefaultCredentialsError(
                 f'Failed to load service account credentials from {filename}'
             ) from exc
+
+    if credential_type == _EXTERNAL_ACCOUNT_TYPE:
+        credentials, _ = _get_external_account_credentials(info, filename=filename)
+        return credentials
 
     raise exceptions.DefaultCredentialsError(
         f'The file {filename} does not have a valid type. Type is {credential_type}, '

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.15.0',
+    version='4.15.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
For external_accounts (like that authenticated from OIDC), credential generation fails:

```
error: Exception calling application: The file /home/runner/work/cpg-infrastructure-private/cpg-infrastructure-private/gha-creds-a71bcdcc6dd941f6.json does not have a valid type. Type is external_account, expected one of ('authorized_user', 'service_account', 'external_account', 'external_account_authorized_user', 'impersonated_service_account', 'gdch_service_account').
```

We don't implement it, and I for the life of me can't get the refresh of credentials working. I _believe_, it's effectively because you need to impersonate a set of credentials. I tried about 30 different combinations, but I keep getting combinations of errors that neither I, Bard or ChatGPT could solve.

This does successfully generate the credentials, with an audience and claim.

Potential threads:

* https://stackoverflow.com/questions/76346361/github-actions-to-gcp-oidc-error-403-unable-to-acquire-impersonated-credential
* https://stackoverflow.com/questions/71559312/github-action-to-gcp-unable-to-acquire-impersonated-credentials-no-access-tok

Closes #139 