### PR TITLE
Restrict docker push to main only

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,5 @@
 name: Docker
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -40,12 +39,7 @@ jobs:
       run: |
         docker build -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }} .
 
-    - name: push sha
-      run: |
-        docker push $IMAGE_NAME:${{ github.sha }}
-
     - name: push version and latest
-      if: ${{ github.event_name != 'pull_request' }}
       run: |
         docker tag $IMAGE_NAME:${{ github.sha }} $IMAGE_NAME:$VERSION
         docker tag $IMAGE_NAME:${{ github.sha }} $IMAGE_NAME:latest

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,9 +1,5 @@
 name: Package
 on:
-  # Building on pull-requests, manual dispatch, and pushes to main; but restricting
-  # publishing only to main pushes and manual dispatch with `if`s in specific steps.
-  pull_request:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -32,9 +28,8 @@ jobs:
 
     - name: Publish the wheel to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ github.event_name != 'pull_request' }}
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: dist/
-        skip_existing: true
+        packages-dir: dist/
+        skip-existing: true


### PR DESCRIPTION
I don't think this image is used, but rather than delete, I'll just patch the non-main workaround for this and the package command