### PR TITLE
Migrate get_batch wrapper to cpg-utils

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.17.1
+current_version = 4.18.0
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.17.0
+current_version = 4.17.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.17.0
+  VERSION: 4.17.1
 
 jobs:
   docker:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.17.1
+  VERSION: 4.18.0
 
 jobs:
   docker:

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -6,10 +6,12 @@ import re
 import subprocess
 import traceback
 
+from cloudpathlib import AnyPath
+
+# pylint: disable=no-name-in-module
 import google.api_core.exceptions
 import google.auth.transport
 import google.oauth2
-from cloudpathlib import AnyPath
 from google.auth import (
     credentials as google_auth_credentials,
     environment_vars,
@@ -22,8 +24,6 @@ from google.auth._default import (
     _EXTERNAL_ACCOUNT_TYPE,
 )
 from google.auth.transport import requests
-
-# pylint: disable=no-name-in-module
 from google.cloud import secretmanager
 from google.oauth2 import credentials as oauth2_credentials, service_account
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -2,10 +2,15 @@
 
 import asyncio
 import inspect
+import logging
 import os
+import tempfile
 import textwrap
-import typing
-from typing import List, Optional, Union
+import uuid
+
+from typing import List, Literal, Optional, Union
+
+import toml
 
 import hail as hl
 import hailtop.batch as hb
@@ -17,8 +22,10 @@ from cpg_utils.config import (
     ConfigError,
     get_config,
     retrieve,
+    set_config_paths,
     try_get_ar_guid,
 )
+
 
 # template commands strings
 GCLOUD_AUTH_COMMAND = """\
@@ -26,6 +33,228 @@ export GOOGLE_APPLICATION_CREDENTIALS=/gsa-key/key.json
 gcloud -q auth activate-service-account \
 --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 """
+
+
+_batch: Optional['Batch'] = None
+
+
+def get_batch(
+    name: str | None = None, default_python_image: str | None = None
+) -> 'Batch':
+    """
+    Wrapper around Hail's `Batch` class, which allows to register created jobs
+    This has been migrated (currently duplicated) out of cpg_workflows
+
+    Parameters
+    ----------
+    name : str, optional, name for the batch
+    default_python_image : str, optional, default python image to use
+
+    Returns
+    -------
+    If there are scheduled jobs, return the batch
+    If there are no jobs to create, return None
+    """
+    global _batch  # pylint: disable=global-statement
+    backend: hb.Backend
+    if _batch is None:
+        if get_config()['hail'].get('backend', 'batch') == 'local':
+            logging.info('Initialising Hail Batch with local backend')
+            backend = hb.LocalBackend(
+                tmp_dir=tempfile.mkdtemp('batch-tmp'),
+            )
+        else:
+            logging.info('Initialising Hail Batch with service backend')
+            backend = hb.ServiceBackend(
+                billing_project=get_config()['hail']['billing_project'],
+                remote_tmpdir=dataset_path('batch-tmp', category='tmp'),
+                token=os.environ.get('HAIL_TOKEN'),
+            )
+        _batch = Batch(
+            name=name or get_config()['workflow'].get('name'),
+            backend=backend,
+            pool_label=get_config()['hail'].get('pool_label'),
+            cancel_after_n_failures=get_config()['hail'].get('cancel_after_n_failures'),
+            default_timeout=get_config()['hail'].get('default_timeout'),
+            default_memory=get_config()['hail'].get('default_memory'),
+            default_python_image=default_python_image
+            or get_config()['workflow']['driver_image'],
+        )
+    return _batch
+
+
+class Batch(hb.Batch):
+    """
+    Thin subclass of the Hail `Batch` class. The aim is to be able to register
+    created jobs, in order to print statistics before submitting the Batch.
+    """
+
+    def __init__(
+        self,
+        name,
+        backend,
+        *args,
+        pool_label=None,
+        **kwargs,
+    ):
+        super().__init__(name, backend, *args, **kwargs)
+        # Job stats registry:
+        self.job_by_label = {}
+        self.job_by_stage = {}
+        self.job_by_tool = {}
+        self.total_job_num = 0
+        self.pool_label = pool_label
+        if not get_config()['hail'].get('dry_run') and not isinstance(
+            self._backend, hb.LocalBackend
+        ):
+            self._copy_configs_to_remote()
+
+    def _copy_configs_to_remote(self):
+        """If configs are local files, copy them to remote"""
+        remote_dir = to_path(self._backend.remote_tmpdir) / 'config'
+        config_path = remote_dir / (str(uuid.uuid4()) + '.toml')
+        with config_path.open('w') as f:
+            toml.dump(dict(get_config()), f)
+        set_config_paths([str(config_path)])
+
+    def _process_attributes(
+        self,
+        name: str | None = None,
+        attributes: dict | None = None,
+    ) -> tuple[str, dict[str, str]]:
+        """
+        Use job attributes to make the job name more descriptive, and add
+        labels for Batch pre-submission stats.
+        """
+        if not name:
+            raise ValueError('Error: job name must be defined')
+
+        self.total_job_num += 1
+
+        attributes = attributes or {}
+        stage = attributes.get('stage')
+        dataset = attributes.get('dataset')
+        sequencing_group = attributes.get('sequencing_group')
+        participant_id = attributes.get('participant_id')
+        sequencing_groups: set[str] = set(attributes.get('sequencing_groups') or [])
+        if sequencing_group:
+            sequencing_groups.add(sequencing_group)
+        part = attributes.get('part')
+        label = attributes.get('label', name)
+        tool = attributes.get('tool')
+        if not tool and name.endswith('Dataproc cluster'):
+            tool = 'hailctl dataproc'
+
+        # pylint: disable=W1116
+        assert isinstance(stage, str | None)
+        assert isinstance(dataset, str | None)
+        assert isinstance(sequencing_group, str | None)
+        assert isinstance(participant_id, str | None)
+        assert isinstance(part, str | None)
+        assert isinstance(label, str | None)
+
+        name = make_job_name(
+            name=name,
+            sequencing_group=sequencing_group,
+            participant_id=participant_id,
+            dataset=dataset,
+            part=part,
+        )
+
+        if label not in self.job_by_label:
+            self.job_by_label[label] = {'job_n': 0, 'sequencing_groups': set()}
+        self.job_by_label[label]['job_n'] += 1
+        self.job_by_label[label]['sequencing_groups'] |= sequencing_groups
+
+        if stage not in self.job_by_stage:
+            self.job_by_stage[stage] = {'job_n': 0, 'sequencing_groups': set()}
+        self.job_by_stage[stage]['job_n'] += 1
+        self.job_by_stage[stage]['sequencing_groups'] |= sequencing_groups
+
+        if tool not in self.job_by_tool:
+            self.job_by_tool[tool] = {'job_n': 0, 'sequencing_groups': set()}
+        self.job_by_tool[tool]['job_n'] += 1
+        self.job_by_tool[tool]['sequencing_groups'] |= sequencing_groups
+
+        attributes['sequencing_groups'] = list(sorted(list(sequencing_groups)))
+        fixed_attrs = {k: str(v) for k, v in attributes.items()}
+        return name, fixed_attrs
+
+    def run(self, **kwargs):  # pylint: disable=R1710,W0221
+        """
+        Execute a batch. Overridden to print pre-submission statistics.
+        Pylint disables:
+        - R1710: Either all return statements in a function should return an expression,
+          or none of them should.
+          - if no jobs are present, no batch is returned. Hail should have this behaviour...
+        - W0221: Arguments number differs from overridden method
+          - this wrapper makes use of **kwargs, which is being passed to the super().run() method
+        """
+        if not self._jobs:
+            logging.error('No jobs to submit')
+            return
+
+        for job in self._jobs:
+            job.name, job.attributes = self._process_attributes(
+                job.name, job.attributes
+            )
+            # We only have dedicated pools for preemptible machines.
+            # _preemptible defaults to None, so check explicitly for False.
+            # pylint: disable=W0212
+            if self.pool_label and job._preemptible is not False:
+                job._pool_label = self.pool_label
+            copy_common_env(job)
+
+        logging.info(f'Will submit {self.total_job_num} jobs')
+
+        def _print_stat(_d: dict, default_label: str | None = None):
+            for label, stat in _d.items():
+                label = label or default_label
+                msg = f'{stat["job_n"]} job'
+                if stat['job_n'] > 1:
+                    msg += 's'
+                if (sg_count := len(stat['sequencing_groups'])) > 0:
+                    msg += f' for {sg_count} sequencing group'
+                    if sg_count > 1:
+                        msg += 's'
+                logging.info(f'  {label}: {msg}')
+
+        logging.info('Split by stage:')
+        _print_stat(self.job_by_stage, default_label='<not in stage>')
+
+        logging.info(f'Split by tool:')
+        _print_stat(self.job_by_tool, default_label='<tool is not defined>')
+
+        kwargs.setdefault('dry_run', get_config()['hail'].get('dry_run'))
+        kwargs.setdefault(
+            'delete_scratch_on_exit', get_config()['hail'].get('delete_scratch_on_exit')
+        )
+        if isinstance(self._backend, hb.LocalBackend):
+            # Local backend does not support "wait"
+            if 'wait' in kwargs:
+                del kwargs['wait']
+        return super().run(**kwargs)
+
+
+def make_job_name(
+    name: str,
+    sequencing_group: str | None = None,
+    participant_id: str | None = None,
+    dataset: str | None = None,
+    part: str | None = None,
+) -> str:
+    """
+    Extend the descriptive job name to reflect job attributes.
+    """
+    if sequencing_group and participant_id:
+        sequencing_group = f'{sequencing_group}/{participant_id}'
+    if sequencing_group and dataset:
+        name = f'{dataset}/{sequencing_group}: {name}'
+    elif dataset:
+        name = f'{dataset}: {name}'
+    if part:
+        name += f', {part}'
+    return name
 
 
 def init_batch(**kwargs):
@@ -528,8 +757,7 @@ python3 script.py
 
 
 def start_query_context(
-    query_backend: typing.Literal['spark', 'batch', 'local', 'spark_local']
-    | None = None,
+    query_backend: Literal['spark', 'batch', 'local', 'spark_local'] | None = None,
     log_path: str | None = None,
     dataset: str | None = None,
     billing_project: str | None = None,

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -94,7 +94,7 @@ class Batch(hb.Batch):
         name,
         backend,
         *,
-        pool_label=None,
+        pool_label: Optional[str] = None,
         attributes: Optional[Dict[str, str]] = None,
         **kwargs,
     ):
@@ -104,9 +104,9 @@ class Batch(hb.Batch):
 
         super().__init__(name, backend, attributes=_attributes, **kwargs)
         # Job stats registry:
-        self.job_by_label = {}
-        self.job_by_stage = {}
-        self.job_by_tool = {}
+        self.job_by_label: Dict = {}
+        self.job_by_stage: Dict = {}
+        self.job_by_tool: Dict = {}
         self.total_job_num = 0
         self.pool_label = pool_label
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.17.1',
+    version='4.18.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.17.0',
+    version='4.17.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Steals the get_batch wrapper structure from cpg_workflows (library within production-pipelines)

Placement of this content in cpg-utils will remove a direct dependency between ad-hoc analysis workflows and the core production-pipelines library