### PR TITLE
Don't print config content by default

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.18.0
+current_version = 4.18.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.18.0
+  VERSION: 4.18.1
 
 jobs:
   docker:

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -98,7 +98,7 @@ def append_config_paths(config_paths: list[str]) -> None:
     set_config_paths(config_paths)
 
 
-def get_config(print_config=True) -> frozendict:
+def get_config(print_config=False) -> frozendict:
     """Returns the configuration dictionary.
 
     Call `set_config_paths` beforehand to override the default path.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'boto3==1.28.56',
         'botocore==1.31.56',
-        'google-auth>=1.27.0',
+        'google-auth>=2.22.0',
         'google-cloud-secret-manager',
         'cloudpathlib[all]',
         'toml',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.18.0',
+    version='4.18.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'boto3==1.28.56',
         'botocore==1.31.56',
-        'google-auth>=2.22.0',
+        'google-auth>=1.27.0',
         'google-cloud-secret-manager',
         'cloudpathlib[all]',
         'toml',


### PR DESCRIPTION
This is very petty...

The config module is currently set up to print the config contents by default each time a new config is loaded. In the pipeline startup the config content is repeated 3 times resulting in a huge wall of redundant text. This also clouds the logging for failed tests etc. and is generally not useful.

The first get_config invocation in the pipeline is easy to find, but I haven't located the subsequent 2 calls that trigger re-printing of the same content...

Instead of mucking about in the prod-pipes codebase to track down the exact calls, how do you feel about treating this at source - alter the default behaviour not to print to logging, then set `get_config(True)` as a deliberate action (e.g. the first time the config is loaded, then never again)

Proposal generally approved on Slack: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1700002730474369