### PR TITLE
Driver as default bash image

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.18.2
+current_version = 4.18.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.18.2
+  VERSION: 4.18.3
 
 jobs:
   docker:

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -83,7 +83,8 @@ def get_batch(
             cancel_after_n_failures=get_config()['hail'].get('cancel_after_n_failures'),
             default_timeout=get_config()['hail'].get('default_timeout'),
             default_memory=get_config()['hail'].get('default_memory'),
-            default_image=default_bash_image or get_config()['workflow']['driver_image'],
+            default_image=default_bash_image
+            or get_config()['workflow']['driver_image'],
             default_python_image=default_python_image
             or get_config()['workflow']['driver_image'],
             attributes=attributes,

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -41,8 +41,8 @@ def reset_batch():
 def get_batch(
     name: str | None = None,
     *,
+    default_image: str | None = None,
     default_python_image: str | None = None,
-    default_bash_image: str | None = None,
     attributes: Optional[Dict[str, str]] = None,
     **kwargs,
 ) -> 'Batch':
@@ -53,8 +53,8 @@ def get_batch(
     Parameters
     ----------
     name : str, optional, name for the batch
+    default_image : str, optional, default bash job (default) image to use
     default_python_image : str, optional, default python image to use
-    default_bash_image : str, optional, default bash job (default) image to use
 
     Returns
     -------
@@ -83,7 +83,7 @@ def get_batch(
             cancel_after_n_failures=get_config()['hail'].get('cancel_after_n_failures'),
             default_timeout=get_config()['hail'].get('default_timeout'),
             default_memory=get_config()['hail'].get('default_memory'),
-            default_image=default_bash_image
+            default_image=default_image
             or get_config()['workflow']['driver_image'],
             default_python_image=default_python_image
             or get_config()['workflow']['driver_image'],

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -42,6 +42,7 @@ def get_batch(
     name: str | None = None,
     *,
     default_python_image: str | None = None,
+    default_bash_image: str | None = None,
     attributes: Optional[Dict[str, str]] = None,
     **kwargs,
 ) -> 'Batch':
@@ -53,6 +54,7 @@ def get_batch(
     ----------
     name : str, optional, name for the batch
     default_python_image : str, optional, default python image to use
+    default_bash_image : str, optional, default bash job (default) image to use
 
     Returns
     -------
@@ -81,6 +83,7 @@ def get_batch(
             cancel_after_n_failures=get_config()['hail'].get('cancel_after_n_failures'),
             default_timeout=get_config()['hail'].get('default_timeout'),
             default_memory=get_config()['hail'].get('default_memory'),
+            default_image=default_bash_image or get_config()['workflow']['driver_image'],
             default_python_image=default_python_image
             or get_config()['workflow']['driver_image'],
             attributes=attributes,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.18.2',
+    version='4.18.3',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/test/input/test_conf.toml
+++ b/test/input/test_conf.toml
@@ -5,7 +5,7 @@ dataset_gcp_project = "mito-disease"
 name = "test conf"
 sequencing_type = "genome"
 output_prefix = "this_is_a_test"
-driver_image = 'ubuntu:20.0'
+driver_image = 'ubuntu:22.04'
 
 [hail]
 backend = "local"

--- a/test/test_hail_batch.py
+++ b/test/test_hail_batch.py
@@ -30,6 +30,8 @@ def test_batch_creation(test_conf):
     job1 = batch.new_bash_job(name='test_job1')
     job1.command('echo "I am a test"')
     assert len(batch._jobs) == 1
+    print(batch._jobs[0].__dict__)
+    assert False
     batch.run(wait=False)
 
 

--- a/test/test_hail_batch.py
+++ b/test/test_hail_batch.py
@@ -30,8 +30,6 @@ def test_batch_creation(test_conf):
     job1 = batch.new_bash_job(name='test_job1')
     job1.command('echo "I am a test"')
     assert len(batch._jobs) == 1
-    print(batch._jobs[0].__dict__)
-    assert False
     batch.run(wait=False)
 
 


### PR DESCRIPTION
We don't set a default image for BashJob (and we never really did, though some jobs did use `hb.Batch(default_image=XXX)` when creating a batch manually)

This changes the batch creation wrapper to set the driver image as the bash job default if not otherwise specified, which would otherwise default to a naked ubuntu:22