### PR TITLE
Write cloud config and overwrite env variable

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.18.2
+current_version = 4.18.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.18.2
+  VERSION: 4.18.3
 
 jobs:
   docker:

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -6,8 +6,10 @@ import logging
 import os
 import tempfile
 import textwrap
+import uuid
 from typing import Dict, List, Literal, Optional, Union
 
+import toml
 import hail as hl
 import hailtop.batch as hb
 from hail.utils.java import Env
@@ -18,6 +20,7 @@ from cpg_utils.config import (
     ConfigError,
     get_config,
     retrieve,
+    set_config_paths,
     try_get_ar_guid,
 )
 
@@ -115,6 +118,18 @@ class Batch(hb.Batch):
         self.job_by_tool: Dict = {}
         self.total_job_num = 0
         self.pool_label = pool_label
+        if not get_config()['hail'].get('dry_run') and not isinstance(
+            self._backend, hb.LocalBackend
+        ):
+            self._copy_configs_to_remote()
+
+    def _copy_configs_to_remote(self):
+        """If configs are local files, copy them to remote"""
+        remote_dir = to_path(self._backend.remote_tmpdir) / 'config'
+        config_path = remote_dir / (str(uuid.uuid4()) + '.toml')
+        with config_path.open('w') as f:
+            toml.dump(dict(get_config()), f)
+        set_config_paths([str(config_path)])
 
     def _process_job_attributes(
         self,

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -9,9 +9,9 @@ import textwrap
 import uuid
 from typing import Dict, List, Literal, Optional, Union
 
-import toml
 import hail as hl
 import hailtop.batch as hb
+import toml
 from hail.utils.java import Env
 
 from cpg_utils import Path, to_path

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -124,7 +124,15 @@ class Batch(hb.Batch):
             self._copy_configs_to_remote()
 
     def _copy_configs_to_remote(self):
-        """If configs are local files, copy them to remote"""
+        """
+        Combine all config files into a single entry
+        Write that entry to a cloud path
+        Set that cloud path as the config path
+
+        This is crucial in production-pipelines as we combine remote
+        and local files in the driver image, but we can only pass
+        cloudpaths to the worker job containers
+        """
         remote_dir = to_path(self._backend.remote_tmpdir) / 'config'
         config_path = remote_dir / (str(uuid.uuid4()) + '.toml')
         with config_path.open('w') as f:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.18.2',
+    version='4.18.3',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
See https://centrepopgen.slack.com/archives/C030X7WGFCL/p1702345700581549

When the Hail Batch wrapper was migrated from production-pipelines to cpg-utils we removed one function call that seemed unnecessary. The final action when creating a batch was to make a config file and write to a cloud location.

It turns out this is pretty important - Analysis-runner generates one combined config from all the CLI file paths. When cpg-workflows/main.py runs it then combines that AR config with the default config and workflow-specific config, adding all 3 paths to the CPG_CONFIG_PATH env variable (based on local files within production-pipelines).

This missing step (reintroduced by this PR) combines all those 3 files into one config, writes it to a cloud path, then overwrites the env variable with a single path. This is then passed on to all child jobs in the batch.

End product - all child jobs get one config file path they can read remotely, which is a combination of the Driver job config and all workflow-specific configs.