### PR TITLE
Allow init_batch overrides in Query_command

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.18.3
+current_version = 4.19.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.18.3
+  VERSION: 4.19.0
 
 jobs:
   docker:

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -747,6 +747,7 @@ def query_command(
     setup_gcp: bool = False,
     setup_hail: bool = True,
     packages: Optional[List[str]] = None,
+    init_batch_args: list[str] = None
 ) -> str:
     """
     Construct a command to run a python function inside a Hail Batch job.
@@ -755,10 +756,17 @@ def query_command(
     Run a Python Hail Query function inside a Hail Batch job.
     Constructs a command string to use with job.command().
     If hail_billing_project is provided, Hail Query will be initialised.
+
+    init_batch_args can be used to pass additional arguments to init_batch.
+    this is a list of strings, which will be placed into the batch initiation command
+    e.g. "worker_memory='highmem'"
     """
-    init_hail_code = """
+    if init_batch_args is None:
+        init_batch_args = []
+    
+    init_hail_code = f"""
 from cpg_utils.hail_batch import init_batch
-init_batch()
+init_batch({', '.join(init_batch_args)})
 """
 
     python_code = f"""

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -747,7 +747,7 @@ def query_command(
     setup_gcp: bool = False,
     setup_hail: bool = True,
     packages: Optional[List[str]] = None,
-    init_batch_args: list[str] = None
+    init_batch_args: dict[str, str | int] | None = None,
 ) -> str:
     """
     Construct a command to run a python function inside a Hail Batch job.
@@ -758,15 +758,22 @@ def query_command(
     If hail_billing_project is provided, Hail Query will be initialised.
 
     init_batch_args can be used to pass additional arguments to init_batch.
-    this is a list of strings, which will be placed into the batch initiation command
-    e.g. "worker_memory='highmem'"
+    this is a dict of args, which will be placed into the batch initiation command
+    e.g. {'worker_memory': 'highmem'} -> 'init_batch(worker_memory="highmem")'
     """
-    if init_batch_args is None:
-        init_batch_args = []
-    
+
+    # translate any input arguments into an embeddable String
+
+    if init_batch_args:
+        batch_overrides = ', '.join(
+            f'{k}={repr(v)}' for k, v in init_batch_args.items()
+        )
+    else:
+        batch_overrides = ''
+
     init_hail_code = f"""
 from cpg_utils.hail_batch import init_batch
-init_batch({', '.join(init_batch_args)})
+init_batch({batch_overrides})
 """
 
     python_code = f"""

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -763,7 +763,6 @@ def query_command(
     """
 
     # translate any input arguments into an embeddable String
-
     if init_batch_args:
         batch_overrides = ', '.join(
             f'{k}={repr(v)}' for k, v in init_batch_args.items()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.18.3',
+    version='4.19.0',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
See: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1707697441632879?thread_ts=1707187236.506529&cid=C030X7WGFCL

The wrapper used in much of the pipeline, `query_command`, doesn't currently support any arguments being passed to `init_batch`. This amendment would allow us to override specific parameters without hugely altering the `query_command` wrapper. This would be useful in situations where a single job executed with query_command needs resource/spec overrides.