### PR TITLE
Quote here-document delimiters to avoid expansion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.19.0
+current_version = 4.19.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.19.0
+  VERSION: 4.19.1
 
 jobs:
   docker:

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -664,7 +664,7 @@ function retry_gs_cp {
 MONITOR_SPACE_CMD = 'df -h; du -sh /io; du -sh /io/batch'
 
 ADD_SCRIPT_CMD = """\
-cat <<EOT >> {script_name}
+cat <<'EOT' >> {script_name}
 {script_contents}
 EOT\
 """
@@ -788,7 +788,7 @@ set -ex
 
 {('pip3 install ' + ' '.join(packages)) if packages else ''}
 
-cat << EOT >> script.py
+cat <<'EOT' >> script.py
 {python_code}
 EOT
 python3 script.py

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.19.0',
+    version='4.19.1',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Without quotes, `{script_contents}` and `{python_code}` are subject to `$var`, \`command\`, and `$((expr))` expansion by the shell.

Context: https://centrepopgen.slack.com/archives/C030X7WGFCL/p1710309190240709?thread_ts=1710299130.937109&cid=C030X7WGFCL