### PR TITLE
Convert workflow to use workload identity federation and update actions versions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -7,6 +7,10 @@ on:
 env:
   VERSION: 4.19.1
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -19,15 +23,16 @@ jobs:
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
       IMAGE_NAME: australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_utils
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
 
     - name: gcloud auth
-      uses: 'google-github-actions/auth@v0'
+      uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ secrets.GH_IMAGES_DEPLOYER_JSON }}
-  
+        workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+        service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+
     - name: set up gcloud sdk
-      uses: google-github-actions/setup-gcloud@v0
+      uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: cpg-common
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -11,9 +11,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'


### PR DESCRIPTION
My recent PR's [Docker action run](https://github.com/populationgenomics/cpg-utils/actions/runs/8274277095) failed with

```
google-github-actions/setup-gcloud failed with: failed to execute command `gcloud --quiet auth activate-service-account gh-images-deployer@cpg-common.iam.gserviceaccount.com --key-file -`:
ERROR: (gcloud.auth.activate-service-account) There was a problem refreshing your current auth tokens:
('invalid_grant: Invalid JWT Signature.', ***'error': 'invalid_grant', 'error_description': 'Invalid JWT Signature.'***)
```

Possibly `secrets.GH_IMAGES_DEPLOYER_JSON` has expired?

This PR converts the workflow to use workload identity federation instead. I've copied `workload_identity_provider` and `service_account` from elsewhere — @illusional perhaps we need to generate new ones for this workflow in this different repository…?

While we're here, update all the other pre-canned actions used to their latest (non-deprecated) node20-based versions.