### PR TITLE
Re-enable shell expansion in `query_command()`'s Python function call

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.19.1
+current_version = 4.19.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 4.19.1
+  VERSION: 4.19.2
 
 permissions:
   contents: read

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -775,9 +775,15 @@ from cpg_utils.hail_batch import init_batch
 init_batch({batch_overrides})
 """
 
+    # the code will be copied verbatim
     python_code = f"""
 {'' if not setup_hail else init_hail_code}
 {inspect.getsource(module)}
+"""
+
+    # but the function call will be shell-expanded, as the arguments may
+    # contain variables requiring expansion, ${BATCH_TMPDIR} in particular
+    python_call = f"""
 {func_name}{func_args}
 """
 
@@ -788,8 +794,11 @@ set -ex
 
 {('pip3 install ' + ' '.join(packages)) if packages else ''}
 
-cat <<'EOT' >> script.py
+cat <<'EOT' > script.py
 {python_code}
+EOT
+cat <<EOT >> script.py
+{python_call}
 EOT
 python3 script.py
 """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='4.19.1',
+    version='4.19.2',
     description='Library of convenience functions specific to the CPG',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The `query_command()` facility actually emits two kinds of code into _script.py_:

- Python code copied from the invoking *.py module, which must not be shell-expanded to avoid surprises
- A function call constructed from the function name and supplied arguments

Even though it is fragile (as Python code is being expanded by the shell!), the latter **should** be shell-expanded as the arguments may contain environment variables. In particular, it is very natural to have Hail resource files as arguments, and these will appear as `"${BATCH_TMPDIR}/foo-123ef/bar"` paths which are designed to be expanded by the shell (rather than by Python code).

It would be preferable and less fragile to have the arguments directly on the `python3` command line directly in shell code, something like this:

```sh
cat <<'EOT' > script.py
import sys
{python_code}
{func_name}(sys.argv[1:])
EOT 
python3 script.py {' '.join(func_args)}
```

However this demolishes the distinction between `str` and `int` arguments, so the smaller change that keeps the argument tuple in Python is the safer fix.

Also **create** _script.py_ (with `>` instead of `>>`) initially rather than appending to it. This avoids executing any already existing _script.py_ contents, e.g., if `query_command()` were used twice in the same job. (Really this ought to use a temporary file name rather than hard-coding it, but this is mostly fine…)

