### PR TITLE
Fix dataproc temp bucket

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.3
+current_version = 5.0.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.0.3
+  VERSION: 5.0.4
 
 permissions:
   contents: read

--- a/cpg_utils/dataproc.py
+++ b/cpg_utils/dataproc.py
@@ -293,7 +293,7 @@ def _add_start_job(  # noqa: C901
         f'--labels={labels_formatted}',
         f'--wheel={get_wheel_from_hail_version(hail_version)}',
         f'--bucket={tmp_bucket}',
-        f'--temp-bucket=cpg-{tmp_bucket}',
+        f'--temp-bucket={tmp_bucket}',
     ]
     if worker_machine_type:
         start_job_command.append(f'--worker-machine-type={worker_machine_type}')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.0.3',
+    version='5.0.4',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Removing the unnecessary `cpg-` prefix from the temp bucket argument in the start dataproc job command. 

See: https://batch.hail.populationgenomics.org.au/batches/443343/jobs/1 
```
ERROR: (gcloud.dataproc.clusters.create) NOT_FOUND: Google Cloud Storage bucket does not exist 'cpg-cpg-seqr-main-tmp'.
```