### PR TITLE
Allow config_retrieve to supply default if no config is available

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.4
+current_version = 5.0.5
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.0.4
+  VERSION: 5.0.5
 
 permissions:
   contents: read

--- a/cpg_utils/config.py
+++ b/cpg_utils/config.py
@@ -227,9 +227,13 @@ def config_retrieve(
     >> config_retrieve(['key1', 'key2', 'key3'], config={}, default=None) is None
     True
     """
-    d = config if config is not None else get_config()
-    if d is None:
-        raise ValueError('No config provided and no default config found')
+    if default is UnsuppliedDefault:
+        d = config if config is not None else get_config()
+    else:
+        try:
+            d = config if config is not None else get_config()
+        except ConfigError:
+            return default
 
     if isinstance(key, str):
         key = [key]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.0.4',
+    version='5.0.5',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -60,10 +60,18 @@ class TestConfig(TestCase):
 
         # check that providing default=None isn't triggering some falsey check
         self.assertIsNone(
-            self.assertIsNone(
-                config_retrieve(['key1', 'key2', 'key3'], config={}, default=None),
-            ),
+            config_retrieve(['key1', 'key2', 'key3'], config={}, default=None),
         )
+
+    def test_retrieve_no_config(self):
+        """
+        Test the config_retrieve behaviour when no config is available
+        """
+        # we've got not config here
+        with self.assertRaises(ConfigError):
+            config_retrieve(['some-key'])
+
+        self.assertIsNone(config_retrieve(['some-key'], default=None))
 
     @patch.dict(os.environ, {'CPG_CONFIG_PATH': test_config_path.as_posix()})
     def test_read_from_env(self):


### PR DESCRIPTION
Action that is failing as the behaviour changed: https://github.com/populationgenomics/metamist/actions/runs/8697673597/job/23870558763