### PR TITLE
Use basicConfig setup for logging.info messages

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.6
+current_version = 5.0.7
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.0.6
+  VERSION: 5.0.7
 
 permissions:
   contents: read

--- a/cpg_utils/cromwell.py
+++ b/cpg_utils/cromwell.py
@@ -386,6 +386,9 @@ def watch_workflow(  # noqa: C901
     )
     from cpg_utils.cromwell_model import WorkflowMetadataModel
 
+    # ensure logging info statements are actually printed
+    logging.basicConfig(level=logging.INFO)
+
     class CromwellError(Exception):
         """Cromwell status error"""
 

--- a/cpg_utils/cromwell.py
+++ b/cpg_utils/cromwell.py
@@ -384,7 +384,6 @@ def watch_workflow(  # noqa: C901
     from cpg_utils.cromwell_model import WorkflowMetadataModel
 
     # Create a logger, ensure info statements are actually printed
-    logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('cromwell_watcher')
     logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.INFO)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.0.6',
+    version='5.0.7',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Follow-up fix on top of https://github.com/populationgenomics/cpg-utils/pull/162

See https://batch.hail.populationgenomics.org.au/batches/443997/jobs/2

By importing Logging, the native logging level is `Warning`. The `info` level messages aren't printed, this includes printing the workflow ID and regular status updates. The first update in a Cromwell-watcher job is during failure (warning-level logging/print statements, everything up to that is logging-level, so not printed to logs)

This change runs a basicConfig to change the logging level to info, which will cause this information to be presented in Hail Batch logs.

During the import from analysis-runner to cpg-utils we went from [this](https://github.com/populationgenomics/analysis-runner/blob/47044d5036f3930c6796a602ae314fa842298dbc/analysis_runner/util.py#L16-L21):

```
logger = logging.getLogger('analysis_runner')
logger.addHandler(logging.StreamHandler())
logger.setLevel(logging.INFO)
# Also update the default severity level for modules that don't use the
# 'analysis-runner' logger.
logging.getLogger().setLevel(logging.INFO)
```

to the simplified `logger =  logging.getLogger(...)` which is how we lost this logging setup.

