### PR TITLE
Abort overlong jobs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.7
+current_version = 5.0.8
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.0.7
+  VERSION: 5.0.8
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.0.7',
+    version='5.0.8',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
After discussion of billing, rogue samples taking 20x longer than they should (and rarely completing) are costing 20x more. Seems obvious, but it wasn't certain if the time taken was idle compute/getting lost in an event queue. 

Specific use-case here is GATK-SV, where running Manta on some individual CRAMs has the same compute cost as processing 150 successful samples, and no results are ever generated.

This PR proposes a kill-switch, so we can set each type of job to have an expected life expectancy, and we can abort jobs which appear to be in an endless loop without having to manually monitor. 

All decisions about the appropriate time permitted will be per-job, and decided in the pipeline. This change only permits an integer to be passed through when starting a Cromwell task which will detect and abort overlong jobs