### PR TITLE
Accept Path as well as str in read_input() and read_input_group()

### DIFF
--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -155,6 +155,17 @@ class Batch(hb.Batch):
             toml.dump(dict(get_config()), f)
         set_config_paths([str(config_path)])
 
+    def read_input(self, path: str | Path) -> hb.resource.InputResourceFile:
+        """As per Hail's read_input() but allows either str or Path."""
+        assert isinstance(path, str | Path)
+        return super().read_input(str(path))
+
+    def read_input_group(self, **kwargs: str | Path) -> hb.resource.ResourceGroup:
+        """As per Hail's read_input_groups() but allows either str or Path."""
+        for path in kwargs.values():
+            assert isinstance(path, str | Path)
+        return super().read_input_group(**{k: str(v) for k, v in kwargs.items()})
+
     def _process_job_attributes(
         self,
         name: str | None = None,


### PR DESCRIPTION
populationgenomics/production-pipelines#727 was yet another example of us forgetting to call `str()` on a CloudPath before passing it to `read_input()`. I do this regularly too, but usually catch it (with great tedium) in local testing.

I'm not sure there's any good reason why we do this to ourselves! Seems like there'd be no conceptual reason why these methods **shouldn't** take a path-like equivalently to a `str`, so this PR suggests overriding these methods in our `hb.Batch` subclass so that they will accept either `str` (as per the superclass) or additionally `CloudPath`/`pathlib.Path`.

(It would be less useful to push this upstream to mainstream Hail, as it doesn't already use cloudpathlib so they would probably prefer to only support `str | pathlib.Path`. But I suppose an alternative to this subclass addition would be to get that much merged upstream and then carry `… | CloudPath` in our local Hail patches…)