### PR TITLE
Add Hail Default version for Dataproc

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.8
+current_version = 5.0.9
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.0.8
+  VERSION: 5.0.9
 
 permissions:
   contents: read

--- a/cpg_utils/cromwell.py
+++ b/cpg_utils/cromwell.py
@@ -573,6 +573,7 @@ def watch_workflow_and_get_output(
     :param job_prefix: Prefix for the job name
     :param workflow_id_file: File containing the workflow ID
     :param outputs_to_collect: dict of output name -> CromwellOutputType
+    :param min_poll_interval: Min time to wait between polls
     :param max_poll_interval: Maximum time to wait between polls
     :param exponential_decrease_seconds: Exponential decrease in wait time
     :param max_sequential_exception_count: Maximum number of exceptions before giving up

--- a/cpg_utils/dataproc.py
+++ b/cpg_utils/dataproc.py
@@ -341,7 +341,7 @@ def _add_submit_job(
     cluster_id: str,
     script: str,
     region: str,
-    hail_version: str,
+    hail_version: str = DEFAULT_HAIL_VERSION,
     pyfiles: list[str] | None = None,
     job_name: str | None = None,
     cluster_name: str | None = None,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.0.8',
+    version='5.0.9',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
It would be unusual for us to provide a non-default hail version for a dataproc cluster, so should we set a default here?

n.b. our prod-pipes code for submitting jobs to an existing cluster doesn't specify this attribute. I don't think we ever use that code path, and due to [this](https://github.com/populationgenomics/production-pipelines/pull/728) we're not failing a mypy inspection on cpg-utils methods.

e.g. [here](https://github.com/populationgenomics/production-pipelines/blob/b8b10456ca0b74d1c60bd8f815684073c7fe6132/cpg_workflows/large_cohort/dataproc_utils.py#L71-L79)