### PR TITLE
Quit after aborting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.1.0
+  VERSION: 5.1.1
 
 permissions:
   contents: read

--- a/cpg_utils/cromwell.py
+++ b/cpg_utils/cromwell.py
@@ -483,7 +483,7 @@ def watch_workflow(  # noqa: C901
             and (datetime.now() - start).total_seconds() >= time_limit_seconds
         ):
             # time to die, Mr. Cromwell
-            logger.info(f'This job has exceeded the max permitted runtime, and will be aborted')
+            logger.info(f'This job has exceeded the max permitted runtime ({time_limit_seconds}s), and will be aborted')
             auth_header = {'Authorization': f'Bearer {_get_cromwell_oauth_token()}'}
             r = requests.post(abort_url, headers=auth_header, timeout=10)
             if not r.ok:

--- a/cpg_utils/cromwell.py
+++ b/cpg_utils/cromwell.py
@@ -483,7 +483,9 @@ def watch_workflow(  # noqa: C901
             and (datetime.now() - start).total_seconds() >= time_limit_seconds
         ):
             # time to die, Mr. Cromwell
-            logger.info(f'This job has exceeded the max permitted runtime ({time_limit_seconds}s), and will be aborted')
+            logger.info(
+                f'This job has exceeded the max permitted runtime ({time_limit_seconds}s), and will be aborted',
+            )
             auth_header = {'Authorization': f'Bearer {_get_cromwell_oauth_token()}'}
             r = requests.post(abort_url, headers=auth_header, timeout=10)
             if not r.ok:

--- a/cpg_utils/cromwell.py
+++ b/cpg_utils/cromwell.py
@@ -483,6 +483,7 @@ def watch_workflow(  # noqa: C901
             and (datetime.now() - start).total_seconds() >= time_limit_seconds
         ):
             # time to die, Mr. Cromwell
+            logger.info(f'This job has exceeded the max permitted runtime, and will be aborted')
             auth_header = {'Authorization': f'Bearer {_get_cromwell_oauth_token()}'}
             r = requests.post(abort_url, headers=auth_header, timeout=10)
             if not r.ok:
@@ -491,6 +492,9 @@ def watch_workflow(  # noqa: C901
                 )
                 _remaining_exceptions -= 1
                 continue
+            # quit if we successfully aborted
+            logger.info(f'Successfully aborted workflow {workflow_id}')
+            return
 
         if _remaining_exceptions <= 0:
             raise CromwellError('Unreachable')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.1.0',
+    version='5.1.1',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Noted by @EddieLF  - the tasks were aborted successfully, but the watcher itself isn't terminated. This results in a cycle of attempting to abort an aborted run over and over 🙃 