### PR TITLE
Fairly quick hack to enable overriding the QoB JAR commit hash

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.1
+current_version = 5.2.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.1.1
+  VERSION: 5.2.0
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.1.1',
+    version='5.2.0',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
When starting a new batch via `init_batch()`, always (if the config contains a `workflow.default_jar_spec_revision` entry) override the QoB JAR to be used.

Compare PR populationgenomics/production-pipelines#972; this adds the capability to cpg-utils so it is generally available, including for scripts not using production-pipelines.

(This will need some bump-versioning too.)