### PR TITLE
Batch.write output takes paths

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.2.0
+current_version = 5.2.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.2.0
+  VERSION: 5.2.1
 
 permissions:
   contents: read

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -223,6 +223,7 @@ class Batch(hb.Batch):
     def write_output(self, resource: _resource.Resource, dest: str):
         """
         Write the output of a resource to a destination.
+        Includes an explicit String cast to prevent failures when calling with Cloud/PosixPath objects
         """
         return super().write_output(resource, str(dest))
 

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -17,6 +17,7 @@ import hail as hl
 import hailtop.batch as hb
 from hail.backend.service_backend import ServiceBackend as InternalServiceBackend
 from hail.utils.java import Env
+from hailtop.batch import resource as _resource
 from hailtop.config import get_deploy_config
 
 from cpg_utils import Path, to_path
@@ -218,6 +219,12 @@ class Batch(hb.Batch):
         attributes['sequencing_groups'] = sorted(sequencing_groups)
         fixed_attrs = {k: str(v) for k, v in attributes.items()}
         return name, fixed_attrs
+
+    def write_output(self, resource: _resource.Resource, dest: str):
+        """
+        Write the output of a resource to a destination.
+        """
+        return super().write_output(resource, str(dest))
 
     def run(self, **kwargs: Any):
         """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.2.0',
+    version='5.2.1',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Hail's write_output method requires the output path to be a String
- Most of our pipeline work uses Paths
- We have 23 instances in production-pipelines of having to do this string conversion inside the method call: https://github.com/search?q=repo%3Apopulationgenomics%2Fproduction-pipelines+str%28output+write_output&type=code

And there's probably a few more where we've done the String conversion before the call.

We're using the `cpg-utils.hail_batch.Batch` wrapper class as our pipeline `Batch`, so inserting this method here means we can use Paths or Strings as the output path variable without getting shouted at by Hail. This just takes the same input arguments as the true method interface, guarantees a String representation of the output path, and calls up to the `Super.write_output` method

It would be nice to change this upstream in Hail, but that would incur a long release time, and would not be mutually exclusive with this patch