### PR TITLE
Use a PEP625-compliant sdist filename and PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -7,16 +7,17 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
-    environment: production
-    defaults:
-      run:
-        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - name: Install prerequisites
+        run: |
+          # Ensure setuptools produces a PEP625-compliant sdist filename
+          pip install --upgrade setuptools
 
       - name: Build
         run: python setup.py sdist
@@ -26,10 +27,27 @@ jobs:
           pip install dist/*
           python -c "import cpg_utils.cloud"
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*
+          retention-days: 2
+
+  upload_pypi:
+    needs: package
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
       - name: Publish the wheel to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: dist/
           skip-existing: true


### PR DESCRIPTION
Similar workflow updates to populationgenomics/analysis-runner#717:—

Ensure the setuptools used is a version that produces a PEP625-compliant sdist filename, i.e., `cpg_utils-*` rather than `cpg-utils-*`. (This requires setuptools ≥69.3.0; the current release is 78.x.) For later Python versions, actions/setup-python does not install setuptools at all, so we will always need to have a setuptools installation step in future. Fixes SET-305.

Also use Trusted Publishing to upload to PyPI, similarly to. As per best practices, separate uploading into a separate job (which requires uploading/download artifacts to communicate between jobs) so that only the PyPI publishing step gets the credentials.