### PR TITLE
Add a version parameter to image_path()

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.2.1
+current_version = 5.3.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.2.1
+  VERSION: 5.3.0
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.2.1',
+    version='5.3.0',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'cloudpathlib[all]',
         'frozendict',
         'google-auth>=1.27.0',
+        'google-cloud-artifact-registry',
         'google-cloud-secret-manager',
         'requests',
         'tabulate',


### PR DESCRIPTION
When given an explicit version, constructs the production image path by looking up the specified tag (specified as the `version` parameter) in the GCP artifact registry and returning the URI returned by the API (modified to use the tag rather than the raw sha256 checksum).

Currently still allows the existing behaviour, for compatibility with existing usage.

Add image lookup functionality to `cpg_utils.cloud`: note that the GCP API appears to only support scanning all images in a repository, so we cache them at the first lookup. Also increase the page_size (default 30) to reduce the overhead; e.g., on our current production images repository (~2000 images), this reduces the `_ensure_image_tags_loaded()` impact from ~1 minute to 10 seconds.