### PR TITLE
Adds class modules to __all__ for discovery

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.3.0
+current_version = 5.3.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.3.0
+  VERSION: 5.3.1
 
 permissions:
   contents: read

--- a/cpg_utils/__init__.py
+++ b/cpg_utils/__init__.py
@@ -2,6 +2,19 @@
 CPG utils
 """
 
+__all__ = [
+    'cloud',
+    'config',
+    'constants',
+    'cromwell',
+    'cromwell_model',
+    'cloudpath_hail_az',
+    'hail_batch',
+    'git',
+    'membership',
+    'slack',
+]
+
 import pathlib
 
 from cloudpathlib import CloudPath
@@ -20,3 +33,4 @@ Path = CloudPath | pathlib.Path
 # Something like to_path() would look better, so we are aliasing a handy method
 # to_anypath to to_path, which returns exactly the Union type we are looking for:
 to_path = to_anypath
+

--- a/cpg_utils/__init__.py
+++ b/cpg_utils/__init__.py
@@ -33,4 +33,3 @@ Path = CloudPath | pathlib.Path
 # Something like to_path() would look better, so we are aliasing a handy method
 # to_anypath to to_path, which returns exactly the Union type we are looking for:
 to_path = to_anypath
-

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.3.0',
+    version='5.3.1',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Change: Adds all modules in cpg_utils to the top level package `__init__.py` to aid in module discovery using simplified inputs

---

Based on various code style discussions, we may want to simplify imports and use full paths to modules/methods in imported libraries. My understanding was that instead of this (deliberately horrible) example:

```
from Pathlib import Path as pathlib_Path
from cpg_utils import Path, to_path
from cpg_utils.hail_batch import init_batch

path_obj: Path = to_path('the/actual/path')
pathlib_obj: pathlib_Path = pathlib_Path('another/path')
init_batch(**)
```

the clarified import/reference would be more like:

```
import Pathlib
import cpg_utils

path_obj: cpg_utils.Path = cpg_utils.to_path('the/actual/path')
pathlib_obj: pathlib.Path = pathlib.Path('another/path')
cpg_utils.hail_batch.init_batch(**)
```

Or.. I've completely misunderstood the intention...

If this is along the line of thinking, we have an issue in that our codebases do a bad job of populating the `__all__` attribute, leading to problems discovering module components unless they're imported in a fully qualified way. 

<img width="621" alt="Screenshot 2025-06-06 at 1 12 14 PM" src="https://github.com/user-attachments/assets/061d2eca-629a-4610-b548-8abd2734b7e6" />


