### PR TITLE
Compress sequencing_groups job attribute when it is very large

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.3.0
+current_version = 5.4.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.3.0
+  VERSION: 5.4.0
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.3.0',
+    version='5.4.0',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Production-pipelines etc workflows generator-side implementation for SET-565.

Add `_pack_attribute()` to compress attribute values if necessary. (Suppress annoying ruff warnings about "incomprehensible" numeric constants.)

Pop `'sequencing_groups'` from the incoming attributes as we may not replace the existing item later. Retain `or []` to continue to guard against the unlikely event of the raw incoming value being None rather than `[]`.

This compresses `sequencing_groups` (and is flexible enough for other attributes in future if necessary) for transport through the Hail database to the billing aggregator. populationgenomics/cpg-infrastructure#308 processes any `sequencing_groups_gzip` attributes it sees, and should be merged and deployed before this PR.