### PR TITLE
Add driver image to all cromwell recovery tasks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.3.0
+current_version = 5.3.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.3.0
+  VERSION: 5.3.1
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.3.0',
+    version='5.3.1',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Slight tweak - Batch backend as the default execution environment

Slightly less slight tweak - all jobs which can recover Cromwell outputs use the `driver_image` as its Docker container. There were instances in the test workflow where some output types would attempt recovery (copy with `gcloud`) in the default image (Ubuntu). This change ensures that all types of recovery task are run in an image with gcloud. 