### PR TITLE
Tag URIs are colon-delimited, unlike at-delimited digest URIs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.4.0
+current_version = 5.4.1
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.4.0
+  VERSION: 5.4.1
 
 permissions:
   contents: read

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -155,7 +155,7 @@ def _ensure_image_tags_loaded(project: str, location: str, repository: str) -> N
             image_tags[name][tag] = DockerImage(
                 image.name,
                 image.uri,
-                f'{base_uri}@{tag}',
+                f'{base_uri}:{tag}',
                 image.image_size_bytes,
                 image.build_time,
             )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.4.0',
+    version='5.4.1',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fix `tag_uri`, which will be returned by `image_path(pkg, version)` and should be delimited with `:` rather than the `@` used to delimit the digest URI it is reconstructed from:

<img width="684" height="305" alt="Screenshot 2025-07-17 at 19 00 48" src="https://github.com/user-attachments/assets/f7342397-0edf-4d0d-8f26-c62e2133cbee" />
