### PR TITLE
Avoid modifying incoming attributes when compressing 'sequencing_groups'

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.4.1
+current_version = 5.4.2
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.4.1
+  VERSION: 5.4.2
 
 permissions:
   contents: read

--- a/cpg_utils/hail_batch.py
+++ b/cpg_utils/hail_batch.py
@@ -189,12 +189,16 @@ class Batch(hb.Batch):
 
         self.total_job_num += 1
 
+        # Multiple jobs in the batch might reference the same attributes dict
+        # object. Avoid modifying the dict object (e.g. with pop() or update())
+        # to avoid changing the attributes of subsequently processed jobs.
+
         attributes = attributes or {}
         stage = attributes.get('stage')
         dataset = attributes.get('dataset')
         sequencing_group = attributes.get('sequencing_group')
         participant_id = attributes.get('participant_id')
-        sequencing_groups: set[str] = set(attributes.pop('sequencing_groups', []) or [])
+        sequencing_groups: set[str] = set(attributes.get('sequencing_groups') or [])
         if sequencing_group:
             sequencing_groups.add(sequencing_group)
         part = attributes.get('part')
@@ -234,10 +238,14 @@ class Batch(hb.Batch):
         self.job_by_tool[tool]['job_n'] += 1
         self.job_by_tool[tool]['sequencing_groups'] |= sequencing_groups
 
-        seqgroups_str = str(sorted(sequencing_groups))
-        attributes.update(self._pack_attribute('sequencing_groups', seqgroups_str))
+        # Ensure all the returned attribute values are presented as strings
+        fixed_attrs = {
+            k: str(v) for k, v in attributes.items() if k != 'sequencing_groups'
+        }
 
-        fixed_attrs = {k: str(v) for k, v in attributes.items()}
+        seqgroups_str = str(sorted(sequencing_groups))
+        fixed_attrs.update(self._pack_attribute('sequencing_groups', seqgroups_str))
+
         return name, fixed_attrs
 
     def run(self, **kwargs: Any):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.4.1',
+    version='5.4.2',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Multiple jobs in the batch might reference the same attributes dict object. Avoid modifying the dict object (e.g. with pop() or update()) to avoid changing the attributes of subsequently processed jobs.

Add a comment to that effect so the next person to modify this function is aware of this part of its contract with its callers!

Compare [batch 631425](https://batch.hail.populationgenomics.org.au/batches/631425/jobs/1) prior to this fix with [batch 631427](https://batch.hail.populationgenomics.org.au/batches/631427/jobs/1) which includes it. (Both use dev cpg-flow images built from populationgenomics/cpg-flow#123. See in particular the `CPGUTILS _process_job_attributes pre  Filter Evens` lines in the logs.)