### PR TITLE
Use newer Slack SDK function instead of obsolete files_upload

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.4.2
+current_version = 5.4.3
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.4.2
+  VERSION: 5.4.3
 
 permissions:
   contents: read

--- a/cpg_utils/slack.py
+++ b/cpg_utils/slack.py
@@ -66,7 +66,12 @@ def send_message(text: str) -> None:
         logging.error(f'Error posting to Slack: {err}')
 
 
-def upload_file(content: bytes, comment: str) -> None:
+def upload_file(
+    content: bytes,
+    comment: str,
+    title: str | None = None,
+    filename: str | None = None,
+) -> None:
     """Uploads `content` to Slack with the given text `comment`, reading credentials from the config."""
     slack_client = _get_slack_sdk().WebClient(token=_get_token())
     try:
@@ -74,6 +79,8 @@ def upload_file(content: bytes, comment: str) -> None:
             channel=_get_channel(),
             content=content,
             initial_comment=comment,
+            title=title,
+            filename=filename,
         )
     except _get_slack_sdk().errors.SlackApiError as err:
         logging.error(f'Error posting to Slack: {err}')

--- a/cpg_utils/slack.py
+++ b/cpg_utils/slack.py
@@ -70,8 +70,8 @@ def upload_file(content: bytes, comment: str) -> None:
     """Uploads `content` to Slack with the given text `comment`, reading credentials from the config."""
     slack_client = _get_slack_sdk().WebClient(token=_get_token())
     try:
-        slack_client.files_upload(
-            channels=_get_channel(),
+        slack_client.files_upload_v2(
+            channel=_get_channel(),
             content=content,
             initial_comment=comment,
         )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.4.2',
+    version='5.4.3',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Slack's `files.upload` endpoint has been [deprecated for eighteen months](https://docs.slack.dev/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay/) and as of 12 November 2025 is no longer functional. Fortunately the SDK provides a `files_upload_v2()` wrapper around the replacement endpoints that is used very similarly.

The `files_upload_v2()` function is underdocumented in the reference documentation, but is reasonably documented in the [SDK source code](https://github.com/slackapi/python-slack-sdk/blob/4601f8a82836cf649ffe0f5d7b08061882d6361f/slack_sdk/web/client.py#L3966). This revised code has been tested against a test slack instance (`upload_file('File text.\n', 'See attachment')`) and posted as expected:

<img width="253" height="157" alt="via files_upload_v2()" src="https://github.com/user-attachments/assets/66b4595c-fdb7-4587-a8da-5430bac76dae" />

Context: https://centrepopgen.slack.com/archives/C03FZL2EF24/p1764715613227479
Fixes [SET-861](https://cpg-populationanalysis.atlassian.net/browse/SET-861).

We will need to rebuild the analysis-runner driver image with this cpg-utils update to get this fix propagated to the storage visualisation (which uses `upload_file()`).

[SET-861]: https://cpg-populationanalysis.atlassian.net/browse/SET-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ