### PR TITLE
Expose parsed docker images

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.4.3
+current_version = 5.4.4
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.4.3
+  VERSION: 5.4.4
 
 permissions:
   contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,16 +24,16 @@ repos:
     hooks:
       - id: cpg-id-checker
 
-  - repo: https://github.com/ambv/black
-    rev: 24.2.0
-    hooks:
-      - id: black
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.3.2
     hooks:
       - id: ruff
+
+  - repo: https://github.com/ambv/black
+    rev: 24.2.0
+    hooks:
+      - id: black
 
     # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,16 +24,16 @@ repos:
     hooks:
       - id: cpg-id-checker
 
+  - repo: https://github.com/ambv/black
+    rev: 24.2.0
+    hooks:
+      - id: black
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.3.2
     hooks:
       - id: ruff
-
-  - repo: https://github.com/ambv/black
-    rev: 24.2.0
-    hooks:
-      - id: black
 
     # Static type analysis (as much as it's possible in python using type hints)
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -7,13 +7,16 @@ import subprocess
 import traceback
 import urllib.parse
 from collections import defaultdict
+from datetime import datetime
 from typing import Any, NamedTuple
+from zoneinfo import ZoneInfo
 
 # pylint: disable=no-name-in-module
 import google.api_core.exceptions
 import google.auth.transport
 import google.oauth2
 from deprecated import deprecated
+from google.api_core.datetime_helpers import to_milliseconds
 from google.auth import (
     credentials as google_auth_credentials,
 )
@@ -42,6 +45,8 @@ IMPLEMENTED_CREDENTIALS_TYPES = (
     _SERVICE_ACCOUNT_TYPE,
     _EXTERNAL_ACCOUNT_TYPE,
 )
+
+TZ = ZoneInfo('Australia/Sydney')
 
 
 def email_from_id_token(id_token_jwt: str) -> str:
@@ -130,7 +135,7 @@ class DockerImage(NamedTuple):
     uri: str
     tag_uri: str
     size: str
-    build_time: str
+    build_time: datetime
 
 
 _repo_image_tags: dict[str, defaultdict[str, dict[str, DockerImage]]] = {}
@@ -151,17 +156,41 @@ def _ensure_image_tags_loaded(project: str, location: str, repository: str) -> N
         name_and_checksum = image.name.rpartition('/dockerImages/')[2]
         name = urllib.parse.unquote(name_and_checksum).rpartition('@')[0]
         base_uri = image.uri.rpartition('@')[0]
+
+        # digest the Google proto DatetimeWithNanoseconds object into a standard python datetime
+        images_build_time_ms = to_milliseconds(image.build_time)
+        build_datetime = datetime.fromtimestamp(images_build_time_ms // 1000, tz=TZ)
+
         for tag in image.tags:
             image_tags[name][tag] = DockerImage(
                 image.name,
                 image.uri,
                 f'{base_uri}:{tag}',
                 image.image_size_bytes,
-                image.build_time,
+                build_datetime,
             )
 
     image_tags.default_factory = None
     _repo_image_tags[repository] = image_tags
+
+
+def get_tags_for_image(
+    project: str,
+    location: str,
+    repository: str,
+    image: str,
+) -> dict[str, DockerImage]:
+    """
+    Ensure available images are loaded, then request all available tags from a specific image
+    """
+    _ensure_image_tags_loaded(project, location, repository)
+    if repository not in _repo_image_tags:
+        raise ValueError(
+            f'repository "{repository}" is not available in the collected tags.',
+        )
+    if image not in _repo_image_tags[repository]:
+        raise ValueError(f'image "{image}" is not available in the collected tags.')
+    return _repo_image_tags[repository][image]
 
 
 def find_image(repository: str | None, name: str, version: str) -> DockerImage:

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -134,7 +134,7 @@ class DockerImage(NamedTuple):
     name: str
     uri: str
     tag_uri: str
-    size: str
+    size: int
     build_time: datetime
 
 

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -9,7 +9,6 @@ import urllib.parse
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, NamedTuple
-from zoneinfo import ZoneInfo
 
 # pylint: disable=no-name-in-module
 import google.api_core.exceptions
@@ -34,6 +33,7 @@ from google.auth.transport import requests
 from google.cloud import artifactregistry, secretmanager
 from google.oauth2 import credentials as oauth2_credentials
 from google.oauth2 import service_account
+from zoneinfo import ZoneInfo
 
 _CLOUD_SDK_MISSING_CREDENTIALS = """\
 Your default credentials were not found. To set up Application Default Credentials, \

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.4.3',
+    version='5.4.4',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a public method to sit on top of the existing artifactory parsing code, allowing a user to view the available tags for a project-location-repository-image combination. The `_repo_image_tags` remains a private variable, but we now have a 'public' method to expose all tags for a known image.

Additional: alteration to types in DockerImage 

- image size should be an int
- build_time is natively a [DateTimeWithNanoseconds](https://googleapis.dev/python/google-api-core/latest/helpers.html#google.api_core.datetime_helpers.DatetimeWithNanoseconds), but I've swapped it to a standard Python datetime object with an attached timezone

