### PR TITLE
Add desktop oauth flow to `get_google_identity_token` method

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.5.0
+current_version = 5.6.0
 commit = True
 tag = False
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,7 @@ on:
       - main
 
 env:
-  VERSION: 5.5.0
+  VERSION: 5.6.0
 
 permissions:
   contents: read

--- a/cpg_utils/cloud.py
+++ b/cpg_utils/cloud.py
@@ -1,18 +1,20 @@
 """Convenience functions related to cloud infrastructure."""
 
+import contextlib
 import json
 import os
 import re
 import subprocess
+import time
 import traceback
 import urllib.parse
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, NamedTuple
 
 # pylint: disable=no-name-in-module
 import google.api_core.exceptions
 import google.auth.transport
-import google.oauth2
 from deprecated import deprecated
 from google.auth import (
     credentials as google_auth_credentials,
@@ -31,6 +33,7 @@ from google.auth.transport import requests
 from google.cloud import artifactregistry, secretmanager
 from google.oauth2 import credentials as oauth2_credentials
 from google.oauth2 import service_account
+from google_auth_oauthlib.flow import InstalledAppFlow
 
 _CLOUD_SDK_MISSING_CREDENTIALS = """\
 Your default credentials were not found. To set up Application Default Credentials, \
@@ -175,9 +178,211 @@ def find_image(repository: str | None, name: str, version: str) -> DockerImage:
         raise ValueError(message) from None
 
 
+class IAPDesktopCredentialsAdapter(google_auth_credentials.Credentials):
+    """Handle the OAuth flow for desktop applications to get an ID token with the IAP client as audience."""
+
+    OAUTH_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+    OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token'  # noqa: S105 - Public Google API endpoint, not a password
+    TOKEN_CACHE_DIR = Path.home() / '.config' / 'cpg' / 'tokens'
+    TOKEN_CACHE_FILE = TOKEN_CACHE_DIR / 'iap_tokens.json'
+
+    def __init__(
+        self,
+        iap_client_id: str,
+        desktop_client_id: str,
+        desktop_client_secret: str,
+    ):
+        super().__init__()
+        self.iap_client_id = iap_client_id
+        self.desktop_client_id = desktop_client_id
+        self.desktop_client_secret = desktop_client_secret
+        self.token: str | None = None
+
+    def _load_cache(self) -> dict:
+        """Load the token cache file."""
+        if not self.TOKEN_CACHE_FILE.exists():
+            return {}
+        try:
+            with open(self.TOKEN_CACHE_FILE) as f:
+                full_cache = json.load(f)
+
+            # The cache is a nested dict: {iap_client_id: {desktop_client_id: { ...tokens... }}}
+            iap_cache = full_cache.get(self.iap_client_id, {})
+            return iap_cache.get(self.desktop_client_id, {})
+        except (json.JSONDecodeError, KeyError):
+            return {}
+
+    def _save_cache(
+        self,
+        id_token: str | None = None,
+        id_token_expires_at: float | None = None,
+        refresh_token: str | None = None,
+    ) -> None:
+        """Save data to the token cache file."""
+        self.TOKEN_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        # Ensure only the user can access the tokens directory
+        self.TOKEN_CACHE_DIR.chmod(0o700)
+
+        full_cache = {}
+        if self.TOKEN_CACHE_FILE.exists():
+            try:
+                with open(self.TOKEN_CACHE_FILE) as f:
+                    full_cache = json.load(f)
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        if self.iap_client_id not in full_cache:
+            full_cache[self.iap_client_id] = {}
+
+        if self.desktop_client_id not in full_cache[self.iap_client_id]:
+            full_cache[self.iap_client_id][self.desktop_client_id] = {}
+
+        # Update the specific nested dictionary
+        cache_data = full_cache[self.iap_client_id][self.desktop_client_id]
+        if id_token is not None:
+            cache_data['id_token'] = id_token
+        if id_token_expires_at is not None:
+            cache_data['id_token_expires_at'] = id_token_expires_at
+        if refresh_token is not None:
+            cache_data['refresh_token'] = refresh_token
+
+        # Write to file with restricted permissions (set via directory)
+        with open(self.TOKEN_CACHE_FILE, 'w') as f:
+            json.dump(full_cache, f)
+        # Set file permissions explicitly
+        self.TOKEN_CACHE_FILE.chmod(0o600)
+
+    def _get_cached_id_token(self) -> str | None:
+        """Get cached ID token if it exists and is not expired."""
+        cache = self._load_cache()
+        id_token = cache.get('id_token')
+        expires_at = cache.get('id_token_expires_at', 0)
+
+        # Check if we have an ID token and it expires in more than 5 mins (300 seconds)
+        if id_token and expires_at and time.time() < (expires_at - 300):
+            return id_token
+
+        return None
+
+    def _cache_id_token(self, id_token: str) -> None:
+        """Cache the ID token with its expiration time."""
+        try:
+            claims = jwt.decode(id_token, verify=False)
+            expires_at = claims.get('exp', 0)
+            self._save_cache(id_token=id_token, id_token_expires_at=expires_at)
+        except ValueError:
+            # If the token is invalid or cannot be decoded, simply do not cache it
+            pass
+
+    def _do_oauth_flow(self) -> str:
+        """Perform the OAuth 2.0 authorization flow for desktop apps."""
+        flow = InstalledAppFlow.from_client_config(
+            {
+                'installed': {
+                    'client_id': self.desktop_client_id,
+                    'client_secret': self.desktop_client_secret,
+                    'auth_uri': self.OAUTH_AUTH_URL,
+                    'token_uri': self.OAUTH_TOKEN_URL,
+                },
+            },
+            scopes=['openid', 'https://www.googleapis.com/auth/userinfo.email'],
+        )
+
+        # This will open the browser and start a local server
+        creds = flow.run_local_server(port=0, prompt='consent')
+
+        refresh_token = creds.refresh_token
+        if not refresh_token:
+            raise RuntimeError(
+                'No refresh token in response. Try revoking access and re-authenticating.',
+            )
+
+        self._save_cache(refresh_token=refresh_token)
+        return refresh_token
+
+    def _get_id_token_from_refresh_token(
+        self,
+        request: google.auth.transport.Request,
+        refresh_token: str,
+    ) -> str:
+        """Exchange refresh token for an ID token with the IAP client as aud."""
+        token_data = {
+            'client_id': self.desktop_client_id,
+            'client_secret': self.desktop_client_secret,
+            'refresh_token': refresh_token,
+            'grant_type': 'refresh_token',
+            'audience': self.iap_client_id,
+        }
+
+        # Use the provided transport request instead of the requests library directly
+        response = request(
+            url=self.OAUTH_TOKEN_URL,
+            method='POST',
+            body=urllib.parse.urlencode(token_data).encode('utf-8'),
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        )
+
+        response_body = response.data.decode('utf-8')
+
+        if response.status != 200:  # noqa: PLR2004 - 200 is fine
+            error_info = response_body
+
+            with contextlib.suppress(json.JSONDecodeError):
+                error_info = json.loads(response_body)
+
+            bad_request = 400
+            if response.status == bad_request and 'invalid_grant' in str(error_info):
+                raise RuntimeError(
+                    'Refresh token expired or revoked. Re-authentication required.',
+                )
+            raise RuntimeError(f'Token refresh failed: {error_info}')
+
+        tokens = json.loads(response_body)
+        id_token = tokens.get('id_token')
+
+        if not id_token:
+            raise RuntimeError('No ID token in response')
+
+        return id_token
+
+    def refresh(self, request: google.auth.transport.Request) -> None:
+        """Get an ID token from cache if possible, otherwise attempt to refresh, otherwise perform the OAuth flow."""
+        cached_id_token = self._get_cached_id_token()
+        if cached_id_token:
+            self.token = cached_id_token
+            return
+
+        cache = self._load_cache()
+        refresh_token = cache.get('refresh_token')
+
+        if refresh_token:
+            try:
+                id_token = self._get_id_token_from_refresh_token(request, refresh_token)
+                self._cache_id_token(id_token)
+                self.token = id_token
+                return
+            except RuntimeError as e:
+                # If the refresh token is expired or revoked, clear it and fall through to do the flow again.
+                if 'expired' in str(e).lower() or 'revoked' in str(e).lower():
+                    refresh_token = None
+                    self._save_cache(refresh_token=None)
+                else:
+                    raise
+
+        if not refresh_token:
+            refresh_token = self._do_oauth_flow()
+
+        id_token = self._get_id_token_from_refresh_token(request, refresh_token)
+        self._cache_id_token(id_token)
+        self.token = id_token
+
+
 def get_google_identity_token(
     target_audience: str | None,
     request: google.auth.transport.Request | None = None,
+    enable_desktop_auth: bool = False,
+    desktop_client_id: str | None = None,
+    desktop_client_secret: str | None = None,
 ) -> str:
     """Returns a Google identity token for the given audience."""
     if request is None:
@@ -187,6 +392,25 @@ def get_google_identity_token(
     # a single helper function that captures all of them:
     # https://github.com/googleapis/google-auth-library-python/issues/590
     creds = _get_default_id_token_credentials(target_audience, request)
+
+    # Application default credentials with _AUTHORIZED_USER_TYPE creds can't be used
+    # to access IAP-secured resources. You have to use a desktop OAuth flow.
+    # This will prompt the user to authenticate via their browser, and cache tokens locally
+    # See https://docs.cloud.google.com/iap/docs/authentication-howto#authenticate_from_a_desktop_app
+    # This is implemented conditionally to ensure backwards compatibility with code that expects
+    # User ADC creds without any interactive prompts.
+    if enable_desktop_auth and isinstance(creds, IDTokenCredentialsAdapter):
+        if not (desktop_client_id and desktop_client_secret and target_audience):
+            raise ValueError(
+                'target_audience, desktop_client_id and desktop_client_secret '
+                'are required when enable_desktop_auth is True and using user credentials.',
+            )
+        creds = IAPDesktopCredentialsAdapter(
+            iap_client_id=target_audience,
+            desktop_client_id=desktop_client_id,
+            desktop_client_secret=desktop_client_secret,
+        )
+
     creds.refresh(request)
     token = creds.token
     if not token:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'cloudpathlib[all]',
         'frozendict',
         'google-auth>=1.27.0',
+        'google-auth-oauthlib',
         'google-cloud-artifact-registry',
         'google-cloud-secret-manager',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as f:
 setup(
     name='cpg-utils',
     # This tag is automatically updated by bumpversion
-    version='5.5.0',
+    version='5.6.0',
     description='Library of convenience functions specific to the CPG',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test/test_get_google_identity_token.py
+++ b/test/test_get_google_identity_token.py
@@ -1,0 +1,236 @@
+# ruff: noqa: ARG005 # as there is lots of mocking, there are lots of unused args, so ignore this rule
+import io
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from google.auth import environment_vars
+
+from cpg_utils import cloud
+
+
+@pytest.fixture
+def mock_request() -> MagicMock:
+    return MagicMock()
+
+
+# These tests are pretty heavily mocked, so of slightly questionable usefulness
+# but at least show the different types of tokens that you can get and verify
+# that all code paths work
+
+
+def test_explicit_environ_authorized_user(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_info = {"type": "authorized_user"}
+    mock_creds = MagicMock()
+    mock_creds.id_token = "mock_auth_user_token"  # noqa: S105
+
+    monkeypatch.setenv(environment_vars.CREDENTIALS, "/mock/creds.json")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *args, **kwargs: io.StringIO(json.dumps(mock_info)),
+    )
+    monkeypatch.setattr(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        lambda info, scopes: mock_creds,
+    )
+
+    token = cloud.get_google_identity_token("mock_audience", mock_request)
+    assert token == "mock_auth_user_token"  # noqa: S105
+    mock_creds.refresh.assert_called_once_with(mock_request)
+
+
+def test_explicit_environ_service_account(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_info = {"type": "service_account"}
+    mock_creds = MagicMock()
+    # For service account, IDTokenCredentials.token returns the token directly
+    mock_creds.token = "mock_service_account_token"  # noqa: S105
+
+    monkeypatch.setenv(environment_vars.CREDENTIALS, "/mock/creds.json")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *args, **kwargs: io.StringIO(json.dumps(mock_info)),
+    )
+    monkeypatch.setattr(
+        "google.oauth2.service_account.IDTokenCredentials.from_service_account_info",
+        lambda info, target_audience: mock_creds,
+    )
+
+    token = cloud.get_google_identity_token("mock_audience", mock_request)
+    assert token == "mock_service_account_token"  # noqa: S105
+    mock_creds.refresh.assert_called_once_with(mock_request)
+
+
+def test_explicit_environ_external_account(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_info = {"type": "external_account"}
+
+    monkeypatch.setenv(environment_vars.CREDENTIALS, "/mock/creds.json")
+    monkeypatch.setenv("GOOGLE_IMPERSONATE_IDENTITY", "mock_impersonate_id")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *args, **kwargs: io.StringIO(json.dumps(mock_info)),
+    )
+    monkeypatch.setattr("subprocess.check_output", lambda cmd: b"mock_external_token\n")
+
+    token = cloud.get_google_identity_token("mock_audience", mock_request)
+    assert token == "mock_external_token"  # noqa: S105
+
+
+def test_gcloud_sdk_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_info = {"type": "authorized_user"}
+    mock_creds = MagicMock()
+    mock_creds.id_token = "mock_gcloud_token"  # noqa: S105
+
+    monkeypatch.delenv(environment_vars.CREDENTIALS, raising=False)
+
+    monkeypatch.setattr(
+        "google.auth._cloud_sdk.get_application_default_credentials_path",
+        lambda: "/mock/gcloud/creds.json",
+    )
+    monkeypatch.setattr("os.path.isfile", lambda p: p == "/mock/gcloud/creds.json")
+    monkeypatch.setattr("os.path.exists", lambda p: p == "/mock/gcloud/creds.json")
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *args, **kwargs: io.StringIO(json.dumps(mock_info)),
+    )
+    monkeypatch.setattr(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        lambda info, scopes: mock_creds,
+    )
+
+    token = cloud.get_google_identity_token("mock_audience", mock_request)
+    assert token == "mock_gcloud_token"  # noqa: S105
+    mock_creds.refresh.assert_called_once_with(mock_request)
+
+
+def test_gce_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_creds = MagicMock()
+    mock_creds.token = "mock_gce_token"  # noqa: S105
+
+    monkeypatch.delenv(environment_vars.CREDENTIALS, raising=False)
+
+    monkeypatch.setattr(
+        "google.auth._cloud_sdk.get_application_default_credentials_path",
+        lambda: "/mock/gcloud/creds.json",
+    )
+    monkeypatch.setattr("os.path.isfile", lambda p: False)
+
+    monkeypatch.setattr(
+        "google.auth.compute_engine._metadata.ping",
+        lambda request: True,
+    )
+    monkeypatch.setattr(
+        "google.auth.compute_engine.IDTokenCredentials",
+        lambda request, target_audience, use_metadata_identity_endpoint: mock_creds,
+    )
+
+    token = cloud.get_google_identity_token("mock_audience", mock_request)
+    assert token == "mock_gce_token"  # noqa: S105
+    mock_creds.refresh.assert_called_once_with(mock_request)
+
+
+def test_enable_desktop_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_info = {"type": "authorized_user"}
+    mock_creds = MagicMock()
+    mock_creds.id_token = "mock_auth_user_token"  # noqa: S105
+
+    monkeypatch.setenv(environment_vars.CREDENTIALS, "/mock/creds.json")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *args, **kwargs: io.StringIO(json.dumps(mock_info)),
+    )
+    monkeypatch.setattr(
+        "google.oauth2.credentials.Credentials.from_authorized_user_info",
+        lambda info, scopes: mock_creds,
+    )
+
+    def mock_desktop_refresh(self: Any, _req: Any) -> None:
+        self.token = "mock_desktop_token"  # noqa: S105
+
+    monkeypatch.setattr(
+        "cpg_utils.cloud.IAPDesktopCredentialsAdapter.refresh",
+        mock_desktop_refresh,
+    )
+
+    token = cloud.get_google_identity_token(
+        target_audience="mock_audience",
+        request=mock_request,
+        enable_desktop_auth=True,
+        desktop_client_id="mock_client_id",
+        desktop_client_secret="mock_client_secret",  # noqa: S106
+    )
+    assert token == "mock_desktop_token"  # noqa: S105
+
+
+def test_get_google_identity_token_no_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    monkeypatch.delenv(environment_vars.CREDENTIALS, raising=False)
+
+    monkeypatch.setattr(
+        "google.auth._cloud_sdk.get_application_default_credentials_path",
+        lambda: "/mock/gcloud/creds.json",
+    )
+    monkeypatch.setattr("os.path.isfile", lambda p: False)
+
+    try:
+        from google.auth.compute_engine import _metadata
+
+        monkeypatch.setattr(
+            _metadata,
+            "ping",
+            lambda request: False,
+        )
+    except ImportError:
+        pass
+
+    with pytest.raises(cloud.exceptions.DefaultCredentialsError):
+        cloud.get_google_identity_token("mock_audience", mock_request)
+
+
+def test_explicit_environ_invalid_type(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_request: MagicMock,
+) -> None:
+    mock_info = {"type": "invalid_type"}
+
+    monkeypatch.setenv(environment_vars.CREDENTIALS, "/mock/creds.json")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
+
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *args, **kwargs: io.StringIO(json.dumps(mock_info)),
+    )
+
+    with pytest.raises(cloud.exceptions.DefaultCredentialsError) as exc_info:
+        cloud.get_google_identity_token("mock_audience", mock_request)
+
+    assert "does not have a valid type" in str(exc_info.value)


### PR DESCRIPTION
This method previously would get a user's Application Default Credentials in the case where they had a locally authenticated account. But ADC credentials can't be used to make a request to an IAP secured resource. That requires a OAuth 2.0 ID token which can be obtained by going through the Desktop OAuth flow.

This requires having the user visit a page in a browser which then redirects back to a local URL with an authorization code. The ID Token can then be fetched from Google with a simple request which returns the ID Token and refresh token. These tokens are then cached in a local config dir which allows for subsequent requests to avoid the need to perform the full OAuth flow again.

This flow is only needed for human users, service accounts and compute instances can still retrieve an ID token without the requirement of an interactive flow. This new flow is also implemented conditionally to ensure backwards compatibility with other usages of this method which expect a request from a user to return ADC credentials rather than an ID token.